### PR TITLE
Add OCG-backed long-term agent memory (ports agentspan#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Migration note: users of the old `conductor-agent-sdk*` NuGet packages
   should switch to the `conductor-ai*` package ids — namespaces
   (`Conductor.AI.*`) and APIs are unchanged.
+- **OCG-backed agent memory** (ports agentspan-ai/agentspan#298): new
+  `OCGMemoryStore` (a synchronous `MemoryStore` HTTP adapter over the OCG BFF —
+  search / save / feedback-link minting), plus `Agent.SemanticMemory`,
+  `Agent.MemorySummaryModel`, and `Agent.FeedbackSink`. When an agent's
+  `SemanticMemory` is OCG-backed, the serializer emits `longTermMemory` +
+  `feedbackSink` so the server-side compiler (conductor-oss/conductor
+  `agentspan-server`) inlines pre-run retrieval and post-run distill/save/feedback.
+  Human good/bad capability links are delivered out-of-band via `FeedbackSink` and
+  never shown to the agent's LLM. Example: `Conductor.AI.Examples/27_OcgMemory`.
 
 ### Changed
 

--- a/Conductor.AI.Examples/27_OcgMemory/Example27OcgMemory.csproj
+++ b/Conductor.AI.Examples/27_OcgMemory/Example27OcgMemory.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Conductor.AI/Conductor.AI.csproj" />
+    <Compile Include="../Shared/Settings.cs" />
+  </ItemGroup>
+</Project>

--- a/Conductor.AI.Examples/27_OcgMemory/Program.cs
+++ b/Conductor.AI.Examples/27_OcgMemory/Program.cs
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+// OCG-backed long-term memory with human good/bad feedback links.
+//
+// Enable memory on an agent and the server-side compiler does two things
+// automatically:
+//   - BEFORE a run: relevant past memories (scoped to this agent/user) are
+//     retrieved from OCG and injected into the prompt — no tool call needed.
+//   - AFTER a run: the conversation is summarized (durable facts, not the raw
+//     transcript) by a small internal summarizer agent and saved back to OCG.
+//
+// Feedback is HUMAN-only. Agents never vote. Instead the runtime hands a
+// FeedbackEvent — including signed capability URLs (good/bad) — to the agent's
+// FeedbackSink. A human clicks a link to mark the memory good or bad; the link
+// skips auth (its signature is the authorization). Here the sink just prints the
+// URLs as they'd appear in a Zendesk ticket comment.
+//
+// Requirements:
+//   - Agentspan server with LLM support (AGENTSPAN_SERVER_URL)
+//   - AGENTSPAN_LLM_MODEL set in environment
+//   - OCG_INSTANCE_URL=https://test.contextgraph.io
+//   - OCG_TOKEN=<bearer-token>
+//   - OCG started with a feedback-link secret (OCG_FEEDBACK_LINK_SECRET) for the
+//     capability URLs to be minted.
+
+using Conductor.AI;
+using Conductor.AI.Examples;
+
+var ocgUrl = Environment.GetEnvironmentVariable("OCG_INSTANCE_URL") ?? "";
+// Unlike the server-resolved retrieval tools, the memory store calls OCG directly
+// from the SDK on the client path, so it holds the bearer token.
+var ocgToken = Environment.GetEnvironmentVariable("OCG_TOKEN");
+if (string.IsNullOrEmpty(ocgUrl))
+{
+    Console.Error.WriteLine(
+        "Set OCG_INSTANCE_URL to your OCG instance, e.g. https://test.contextgraph.io");
+    return;
+}
+
+// Deliver the good/bad links to a human. In production this would POST a comment to
+// the Zendesk ticket; here we just print what would be sent.
+static void ZendeskSink(FeedbackEvent e)
+{
+    Console.WriteLine("\n--- would post to Zendesk ticket ---");
+    Console.WriteLine($"Saved memory: {e.MemoryKey}");
+    Console.WriteLine($"Summary: {e.Summary}");
+    if (!string.IsNullOrEmpty(e.GoodUrl))
+    {
+        Console.WriteLine($"  [+] Was this helpful?  {e.GoodUrl}");
+        Console.WriteLine($"  [-] Not helpful:       {e.BadUrl}");
+    }
+    Console.WriteLine("------------------------------------\n");
+}
+
+var store = new OCGMemoryStore(
+    url: ocgUrl,
+    agent: "agent:support",
+    user: "user:alice",
+    token: ocgToken);
+
+var agent = new Agent("support")
+{
+    Model = Settings.LlmModel,
+    Instructions =
+        "You are a customer support agent. Use any relevant context from memory to " +
+        "personalize your answer. A memory labeled [bad] was flagged by a human — " +
+        "treat it with suspicion.",
+    SemanticMemory = new SemanticMemory(store: store, maxResults: 5),
+    FeedbackSink = ZendeskSink,
+};
+
+await using var runtime = new AgentRuntime();
+
+Console.WriteLine("--- Turn 1 ---");
+(await runtime.RunAsync(
+    agent, "Hi, I'm Alice. I'm on the Enterprise plan and prefer email.")).PrintResult();
+
+Console.WriteLine("\n--- Turn 2 (should recall Alice's plan from memory) ---");
+(await runtime.RunAsync(agent, "What plan am I on again?")).PrintResult();

--- a/Conductor.AI.Tests/OcgMemoryTests.cs
+++ b/Conductor.AI.Tests/OcgMemoryTests.cs
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using Conductor.AI;
+using Xunit;
+
+namespace Conductor.AI.Tests;
+
+/// <summary>
+/// Unit tests for OCG-backed long-term memory: the <see cref="OCGMemoryStore"/> HTTP
+/// adapter and the <c>longTermMemory</c> / <c>feedbackSink</c> serializer emission.
+/// Modeled on Python's test_ocg_memory_store.py + test_config_serializer.py additions.
+/// </summary>
+public class OcgMemoryStoreTests
+{
+    // A minimal HttpMessageHandler that routes every request through a func — the C#
+    // analogue of httpx.MockTransport used in the Python tests.
+    private sealed class MockHandler(Func<HttpRequestMessage, HttpResponseMessage> fn) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(fn(request));
+    }
+
+    private static OCGMemoryStore StoreWith(Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        var client = new HttpClient(new MockHandler(handler));
+        return new OCGMemoryStore(url: "https://ocg.test", agent: "agent:a", user: "user:bob", client: client);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode code, string json)
+        => new(code) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    [Fact]
+    public void Add_posts_value_field_and_no_confidence()
+    {
+        string? capturedUrl = null;
+        JsonNode? capturedBody = null;
+
+        var store = StoreWith(req =>
+        {
+            capturedUrl = req.RequestUri!.ToString();
+            capturedBody = JsonNode.Parse(req.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+            return Json(HttpStatusCode.OK, "{\"key\":\"k1\"}");
+        });
+
+        var key = store.Add(new MemoryEntry
+        {
+            Content = "alice prefers email",
+            Metadata = new Dictionary<string, object> { ["key"] = "pref" },
+        });
+
+        Assert.Equal("pref", key);
+        Assert.EndsWith("/api/v1/memories", capturedUrl);
+        var body = capturedBody!.AsObject();
+        Assert.Equal("alice prefers email", body["value"]!.GetValue<string>()); // field is "value", NOT "string_value"
+        Assert.False(body.ContainsKey("string_value"));
+        Assert.False(body.ContainsKey("confidence")); // confidence was removed from the API
+        Assert.Equal("agent:a", body["agent"]!.GetValue<string>());
+        Assert.Equal("user:bob", body["user"]!.GetValue<string>());
+        Assert.Equal("agent_inferred", body["source"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Search_folds_good_bad_signal_into_content()
+    {
+        var store = StoreWith(req =>
+        {
+            Assert.EndsWith("/api/v1/memories/search", req.RequestUri!.ToString());
+            return Json(HttpStatusCode.OK, """
+                {
+                  "memories": [
+                    {
+                      "key": "m1",
+                      "value_preview": "use us-east-1",
+                      "good_count": 2,
+                      "bad_count": 1,
+                      "relevance_score": 0.9,
+                      "feedback_notes": [{"verdict": "bad", "reason": "stale region"}]
+                    }
+                  ]
+                }
+                """);
+        });
+
+        var entries = store.Search("which region", topK: 5);
+        Assert.Single(entries);
+        Assert.Contains("[good 2 / bad 1]", entries[0].Content);
+        Assert.Contains("bad: \"stale region\"", entries[0].Content);
+    }
+
+    [Fact]
+    public void FeedbackLinks_hits_mint_route()
+    {
+        var store = StoreWith(req =>
+        {
+            var path = req.RequestUri!.ToString().Split('?')[0];
+            Assert.EndsWith("/api/v1/memories/k1/feedback-links", path);
+            return Json(HttpStatusCode.OK, """
+                {
+                  "good_url": "https://ocg.test/api/v1/feedback/GOOD",
+                  "bad_url": "https://ocg.test/api/v1/feedback/BAD",
+                  "expires_at": "2026-09-01T00:00:00Z"
+                }
+                """);
+        });
+
+        var links = store.GetFeedbackLinks("k1");
+        Assert.EndsWith("/feedback/GOOD", links.GoodUrl);
+        Assert.EndsWith("/feedback/BAD", links.BadUrl);
+        Assert.Equal("2026-09-01T00:00:00Z", links.ExpiresAt);
+    }
+
+    [Fact]
+    public void Non_2xx_raises()
+    {
+        var store = StoreWith(_ => Json(HttpStatusCode.InternalServerError, "boom"));
+        Assert.Throws<AgentApiException>(() =>
+            store.Add(new MemoryEntry { Content = "x", Metadata = new() { ["key"] = "k" } }));
+    }
+
+    [Fact]
+    public void Blank_url_or_agent_rejected()
+    {
+        Assert.Throws<ArgumentException>(() => new OCGMemoryStore(url: "  ", agent: "agent:a"));
+        Assert.Throws<ArgumentException>(() => new OCGMemoryStore(url: "https://ocg.test", agent: ""));
+    }
+}
+
+/// <summary>
+/// Serializer emission of <c>longTermMemory</c> + <c>feedbackSink</c> — the piece the
+/// server relies on to activate OCG-backed memory on the compiled/deployed path.
+/// Mirrors Python's test_config_serializer.py additions.
+/// </summary>
+public class LongTermMemorySerializerTests
+{
+    private static JsonObject SerializeAgent(Agent agent) => AgentConfigSerializer.SerializeAgent(agent);
+
+    [Fact]
+    public void Serialize_long_term_memory()
+    {
+        var store = new OCGMemoryStore(
+            url: "https://ocg.example.com/",
+            agent: "agent:ce-ticket-resolution",
+            user: "user:alice",
+            scope: "agent");
+        var sm = new SemanticMemory(store: store, maxResults: 7);
+
+        var agent = new Agent("ce_agent")
+        {
+            Model = "openai/gpt-4o",
+            Instructions = "Resolve tickets.",
+            SemanticMemory = sm,
+            MemorySummaryModel = "openai/gpt-4o-mini",
+            FeedbackSink = _ => { },
+        };
+        var cfg = SerializeAgent(agent);
+
+        var ltm = cfg["longTermMemory"]!;
+        Assert.Equal("https://ocg.example.com", ltm["ocgUrl"]!.GetValue<string>()); // trailing slash stripped
+        Assert.Equal("OCG_PUBLIC_KEY", ltm["credential"]!.GetValue<string>());      // server-resolvable name, not token
+        Assert.Equal("agent:ce-ticket-resolution", ltm["agent"]!.GetValue<string>());
+        Assert.Equal("user:alice", ltm["user"]!.GetValue<string>());
+        Assert.Equal("agent", ltm["scope"]!.GetValue<string>());
+        Assert.Equal(7, ltm["maxResults"]!.GetValue<int>());
+        Assert.Equal("openai/gpt-4o-mini", ltm["summaryModel"]!.GetValue<string>());
+
+        Assert.Equal("ce_agent_feedback_sink", cfg["feedbackSink"]!["taskName"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Serialize_long_term_memory_absent()
+    {
+        var agent = new Agent("plain") { Model = "openai/gpt-4o", Instructions = "Hi." };
+        var cfg = SerializeAgent(agent);
+
+        Assert.Null(cfg["longTermMemory"]);
+        Assert.Null(cfg["feedbackSink"]);
+    }
+
+    [Fact]
+    public void Serialize_long_term_memory_summary_model_fallback()
+    {
+        var store = new OCGMemoryStore(url: "https://ocg.example.com", agent: "agent:x");
+        var sm = new SemanticMemory(store: store, maxResults: 5);
+        var agent = new Agent("a") { Model = "anthropic/claude", SemanticMemory = sm };
+        var cfg = SerializeAgent(agent);
+
+        Assert.Equal("anthropic/claude", cfg["longTermMemory"]!["summaryModel"]!.GetValue<string>());
+        Assert.Null(cfg["feedbackSink"]); // no feedback sink -> no feedbackSink emitted
+    }
+
+    [Fact]
+    public void Non_ocg_store_does_not_compile()
+    {
+        // A non-OCG store (plain InMemoryStore) has no base url to call server-side,
+        // so it must NOT emit longTermMemory.
+        var sm = new SemanticMemory(store: new InMemoryStore(), maxResults: 5);
+        var agent = new Agent("a") { Model = "openai/gpt-4o", SemanticMemory = sm };
+        var cfg = SerializeAgent(agent);
+
+        Assert.Null(cfg["longTermMemory"]);
+    }
+}

--- a/Conductor.AI/Agent.cs
+++ b/Conductor.AI/Agent.cs
@@ -190,6 +190,32 @@ public sealed partial class Agent
     /// </summary>
     public TextGate? Gate { get; set; }
 
+    /// <summary>
+    /// OCG-backed long-term memory (see <see cref="OCGMemoryStore"/>). When set with an
+    /// OCG-backed store, the serializer emits a <c>longTermMemory</c> config so the
+    /// server-side compiler auto-injects relevant memories into the prompt before a run
+    /// and, after the run, distills the conversation into a memory. Mirrors Python's
+    /// <c>semantic_memory</c> agent param.
+    /// </summary>
+    public SemanticMemory? SemanticMemory { get; set; }
+
+    /// <summary>
+    /// Optional model override for the conversation-summarizer distiller. Falls back to
+    /// the agent's own <see cref="Model"/> when unset. Emitted as
+    /// <c>longTermMemory.summaryModel</c>.
+    /// </summary>
+    public string? MemorySummaryModel { get; set; }
+
+    /// <summary>
+    /// Sink that receives the human good/bad capability links after a conversation
+    /// memory is saved (out-of-band delivery, e.g. into a Zendesk ticket). The links are
+    /// NEVER shown to the agent's LLM. When set alongside an OCG-backed
+    /// <see cref="SemanticMemory"/>, the serializer emits <c>feedbackSink</c> and the
+    /// runtime registers a <c>{name}_feedback_sink</c> worker so the compiled server path
+    /// can hand the links back to this callback.
+    /// </summary>
+    public Action<FeedbackEvent>? FeedbackSink { get; set; }
+
     public List<string>? RequiredTools { get; set; }
     public string? Introduction { get; set; }
     public Dictionary<string, object>? Metadata { get; set; }
@@ -349,6 +375,12 @@ public sealed class AgentBuilder
     public AgentBuilder WithIncludeContents(string mode) { _agent.IncludeContents = mode; return this; }
     public AgentBuilder WithThinkingBudget(int tokens) { _agent.ThinkingBudgetTokens = tokens; return this; }
     public AgentBuilder WithRequiredTools(params string[] tools) { _agent.RequiredTools = [.. tools]; return this; }
+    /// <summary>OCG-backed long-term memory. See <see cref="Agent.SemanticMemory"/>.</summary>
+    public AgentBuilder WithSemanticMemory(SemanticMemory memory) { _agent.SemanticMemory = memory; return this; }
+    /// <summary>Model override for the memory summarizer. See <see cref="Agent.MemorySummaryModel"/>.</summary>
+    public AgentBuilder WithMemorySummaryModel(string model) { _agent.MemorySummaryModel = model; return this; }
+    /// <summary>Out-of-band sink for human good/bad feedback links. See <see cref="Agent.FeedbackSink"/>.</summary>
+    public AgentBuilder WithFeedbackSink(Action<FeedbackEvent> sink) { _agent.FeedbackSink = sink; return this; }
     public AgentBuilder WithIntroduction(string intro) { _agent.Introduction = intro; return this; }
     public AgentBuilder WithMetadata(Dictionary<string, object> m) { _agent.Metadata = m; return this; }
     /// <summary>Dynamic instructions re-evaluated at each serialization. See <see cref="Agent.InstructionsFn"/>.</summary>

--- a/Conductor.AI/AgentConfigSerializer.cs
+++ b/Conductor.AI/AgentConfigSerializer.cs
@@ -402,7 +402,46 @@ internal static class AgentConfigSerializer
             cfg["cliConfig"] = cli;
         }
 
+        // Long-term (OCG-backed) memory. When present, the server-side compiler
+        // inlines retrieval (pre-loop) + distill/save/feedback (post-loop) steps
+        // so memory works on the deployed/webhook path — not just client run().
+        SerializeLongTermMemory(agent, cfg);
+
         return cfg;
+    }
+
+    /// <summary>
+    /// Serialize an agent's OCG-backed semantic memory to a <c>longTermMemory</c> config
+    /// (plus <c>feedbackSink</c> when a feedback sink is set). No-op unless the agent's
+    /// <see cref="SemanticMemory"/> is backed by an <see cref="OCGMemoryStore"/> — only
+    /// OCG-backed stores compile server-side (they need a base url to call). The
+    /// <c>credential</c> is a SERVER-resolvable secret NAME (e.g. <c>OCG_PUBLIC_KEY</c>),
+    /// never the raw client token; <c>summaryModel</c> falls back to the agent's own model.
+    /// </summary>
+    private static void SerializeLongTermMemory(Agent agent, JsonObject cfg)
+    {
+        if (agent.SemanticMemory?.Store is not OCGMemoryStore store)
+            return;
+
+        var ltm = new JsonObject
+        {
+            ["ocgUrl"] = store.BaseUrl,
+            ["credential"] = string.IsNullOrEmpty(store.Credential) ? "OCG_PUBLIC_KEY" : store.Credential,
+        };
+        if (!string.IsNullOrEmpty(store.Agent)) ltm["agent"] = store.Agent;
+        if (!string.IsNullOrEmpty(store.User)) ltm["user"] = store.User;
+        ltm["scope"] = string.IsNullOrEmpty(store.Scope) ? "agent" : store.Scope;
+        ltm["maxResults"] = agent.SemanticMemory.MaxResults;
+
+        var summaryModel = agent.MemorySummaryModel ?? agent.Model;
+        if (!string.IsNullOrEmpty(summaryModel)) ltm["summaryModel"] = summaryModel;
+
+        cfg["longTermMemory"] = ltm;
+
+        // feedback_sink delivers the human good/bad capability links out-of-band. Emit a
+        // worker ref so the compiled path can call the SDK's feedback-sink worker.
+        if (agent.FeedbackSink is not null)
+            cfg["feedbackSink"] = new JsonObject { ["taskName"] = $"{agent.Name}_feedback_sink" };
     }
 
     private static JsonObject SerializeFrameworkAgent(Agent agent)

--- a/Conductor.AI/OCGMemory.cs
+++ b/Conductor.AI/OCGMemory.cs
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace Conductor.AI;
+
+/// <summary>
+/// OCG (Open Context Graph) backed long-term memory for agents.
+///
+/// <para>Backs the agentspan <see cref="MemoryStore"/> abstraction with an OCG
+/// instance so an agent's memories persist in OCG and ride OCG's feedback-aware
+/// ranking. Implements the synchronous <see cref="MemoryStore"/> interface over
+/// the OCG BFF:</para>
+/// <list type="bullet">
+///   <item><c>Add</c>     -> <c>POST   /api/v1/memories</c></item>
+///   <item><c>Search</c>  -> <c>POST   /api/v1/memories/search</c> (feedback-blended ranking)</item>
+///   <item><c>Delete</c>  -> <c>DELETE /api/v1/memories/{key}</c></item>
+///   <item><c>ListAll</c> -> <c>GET    /api/v1/memories</c></item>
+/// </list>
+///
+/// <para>Design notes: the OCG bearer <c>token</c> is held <b>client-side</b> here
+/// (e.g. from <c>OCG_TOKEN</c>), unlike the server-resolved retrieval tools. Agents
+/// only ever <b>create and read</b> memories — good/bad feedback is human-only and
+/// delivered out-of-band via an agent's <see cref="Agent.FeedbackSink"/>; the signed
+/// capability URLs are never surfaced to the agent's LLM.</para>
+///
+/// <para>When an agent's <see cref="SemanticMemory"/> is backed by this store, the
+/// serializer emits a <c>longTermMemory</c> config so the server-side compiler
+/// inlines retrieval (pre-loop) + distill/save/feedback (post-loop) steps — see
+/// <see cref="AgentConfigSerializer"/>. The <c>credential</c> emitted there is a
+/// server-resolvable secret NAME (e.g. <c>OCG_PUBLIC_KEY</c>), never the raw token.</para>
+/// </summary>
+public sealed class OCGMemoryStore : MemoryStore, IDisposable
+{
+    private readonly HttpClient _client;
+    private readonly bool _ownsClient;
+
+    /// <summary>Base URL of the OCG instance (trailing slash stripped).</summary>
+    public string BaseUrl { get; }
+
+    /// <summary>Agent owner key, e.g. <c>"agent:support"</c>.</summary>
+    public string Agent { get; }
+
+    /// <summary>Optional user owner, e.g. <c>"user:alice"</c>.</summary>
+    public string? User { get; }
+
+    /// <summary>
+    /// Server-resolvable credential NAME (default <c>"OCG_PUBLIC_KEY"</c>) for the OCG
+    /// bearer token. Used by the COMPILED/deployed path — the server resolves this via
+    /// a <c>#{NAME}</c> HTTP-header placeholder. Distinct from the raw client token.
+    /// </summary>
+    public string Credential { get; }
+
+    /// <summary>Memory scope for writes (default <c>"user"</c>).</summary>
+    public string Scope { get; }
+
+    /// <param name="url">Base URL of the OCG instance (required).</param>
+    /// <param name="agent">Agent owner key, e.g. <c>"agent:support"</c> (required).</param>
+    /// <param name="user">Optional user owner, e.g. <c>"user:alice"</c>.</param>
+    /// <param name="token">OCG bearer token, held client-side (e.g. from <c>OCG_TOKEN</c>).
+    /// Used by the client-side path. Ignored when <paramref name="client"/> is supplied.</param>
+    /// <param name="credential">Server-resolvable credential NAME (default <c>"OCG_PUBLIC_KEY"</c>).</param>
+    /// <param name="scope">Memory scope for writes (default <c>"user"</c>).</param>
+    /// <param name="timeoutSeconds">Per-request timeout in seconds.</param>
+    /// <param name="client">Optional pre-built <see cref="HttpClient"/> (mainly for tests).</param>
+    public OCGMemoryStore(
+        string url,
+        string agent,
+        string? user = null,
+        string? token = null,
+        string credential = "OCG_PUBLIC_KEY",
+        string scope = "user",
+        double timeoutSeconds = 10.0,
+        HttpClient? client = null)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentException("OCGMemoryStore requires a non-blank OCG instance url", nameof(url));
+        if (string.IsNullOrWhiteSpace(agent))
+            throw new ArgumentException("OCGMemoryStore requires a non-blank agent owner", nameof(agent));
+
+        BaseUrl = url.Trim().TrimEnd('/');
+        Agent = agent;
+        User = user;
+        Credential = credential;
+        Scope = scope;
+
+        if (client is not null)
+        {
+            _client = client;
+            _ownsClient = false;
+        }
+        else
+        {
+            _client = new HttpClient { Timeout = TimeSpan.FromSeconds(timeoutSeconds) };
+            if (!string.IsNullOrEmpty(token))
+                _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            _ownsClient = true;
+        }
+    }
+
+    // ── MemoryStore interface ───────────────────────────────────────────
+
+    /// <inheritdoc />
+    public override string Add(MemoryEntry entry)
+    {
+        var key = FirstNonEmpty(
+            entry.Id,
+            entry.Metadata.TryGetValue("key", out var k) ? k?.ToString() : null)
+            ?? HashKey(entry.Content);
+
+        var tags = new JsonArray();
+        if (entry.Metadata.TryGetValue("tags", out var t) && t is not string
+            && t is System.Collections.IEnumerable seq)
+        {
+            foreach (var item in seq) tags.Add(item?.ToString() ?? "");
+        }
+
+        var description = entry.Content.Length > 200 ? entry.Content[..200] : entry.Content;
+        var body = new JsonObject
+        {
+            ["key"] = key,
+            ["agent"] = Agent,
+            ["value"] = entry.Content,
+            ["description"] = description,
+            ["scope"] = Scope,
+            ["source"] = "agent_inferred",
+            ["tags"] = tags,
+        };
+        if (User is not null) body["user"] = User;
+
+        Request(HttpMethod.Post, "/api/v1/memories", body);
+        return key;
+    }
+
+    /// <inheritdoc />
+    public override List<MemoryEntry> Search(string query, int topK = 5)
+    {
+        var body = new JsonObject
+        {
+            ["query"] = query,
+            ["agent"] = Agent,
+            ["limit"] = topK,
+            ["include_shared"] = true,
+        };
+        if (User is not null) body["user"] = User;
+
+        var resp = Request(HttpMethod.Post, "/api/v1/memories/search", body);
+        var memories = resp?["memories"]?.AsArray();
+        var outList = new List<MemoryEntry>();
+        if (memories is null) return outList;
+
+        foreach (var m in memories)
+        {
+            if (m is null) continue;
+            outList.Add(new MemoryEntry
+            {
+                Id = m["key"]?.GetValue<string>() ?? "",
+                Content = WithSignal(m["value_preview"]?.GetValue<string>() ?? "", m),
+                Metadata = new Dictionary<string, object>
+                {
+                    ["relevance_score"] = ReadDouble(m, "relevance_score"),
+                    ["good_count"] = ReadInt(m, "good_count"),
+                    ["bad_count"] = ReadInt(m, "bad_count"),
+                },
+            });
+        }
+        return outList;
+    }
+
+    /// <inheritdoc />
+    public override bool Delete(string id)
+    {
+        var path = $"/api/v1/memories/{Uri.EscapeDataString(id)}" + Query(("agent", Agent), ("user", User));
+        try
+        {
+            Request(HttpMethod.Delete, path);
+        }
+        catch (AgentApiException)
+        {
+            return false;
+        }
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override void Clear()
+    {
+        // No bulk-clear endpoint — fan out over the listed keys. Guard usage:
+        // this deletes every memory for the configured agent/user.
+        foreach (var e in ListAll()) Delete(e.Id);
+    }
+
+    /// <inheritdoc />
+    public override List<MemoryEntry> ListAll()
+    {
+        var path = "/api/v1/memories" + Query(("agent", Agent), ("limit", "200"), ("user", User));
+        var resp = Request(HttpMethod.Get, path);
+        var memories = resp?["memories"]?.AsArray();
+        var outList = new List<MemoryEntry>();
+        if (memories is null) return outList;
+        foreach (var m in memories)
+        {
+            if (m is null) continue;
+            outList.Add(new MemoryEntry
+            {
+                Id = m["key"]?.GetValue<string>() ?? "",
+                Content = m["value_preview"]?.GetValue<string>() ?? "",
+            });
+        }
+        return outList;
+    }
+
+    // ── Capability feedback links (human-only, out-of-band) ─────────────
+
+    /// <summary>
+    /// Mint signed good/bad capability URLs for a memory. The URLs require no OCG
+    /// login — a human (e.g. a support engineer) clicks them to vote. Requires the
+    /// OCG instance to have a feedback-link secret configured (else OCG returns 501).
+    /// </summary>
+    public FeedbackLinks GetFeedbackLinks(string key)
+    {
+        var path = $"/api/v1/memories/{Uri.EscapeDataString(key)}/feedback-links"
+                   + Query(("agent", Agent), ("user", User));
+        var resp = Request(HttpMethod.Post, path);
+        return new FeedbackLinks(
+            GoodUrl: resp?["good_url"]?.GetValue<string>(),
+            BadUrl: resp?["bad_url"]?.GetValue<string>(),
+            ExpiresAt: resp?["expires_at"]?.GetValue<string>());
+    }
+
+    // ── HTTP plumbing ───────────────────────────────────────────────────
+
+    private JsonNode? Request(HttpMethod method, string path, JsonNode? body = null)
+    {
+        var url = BaseUrl + path;
+        using var req = new HttpRequestMessage(method, url);
+        if (body is not null)
+            req.Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json");
+
+        HttpResponseMessage resp;
+        try
+        {
+            resp = _client.SendAsync(req).GetAwaiter().GetResult();
+        }
+        catch (HttpRequestException exc) // network/timeout
+        {
+            throw new AgentApiException(0, exc.Message, url);
+        }
+
+        using (resp)
+        {
+            var text = resp.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            if ((int)resp.StatusCode >= 400)
+                throw new AgentApiException((int)resp.StatusCode, text, text);
+            return string.IsNullOrEmpty(text) ? null : JsonNode.Parse(text);
+        }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Fold the human good/bad signal into a search result's content so the injected
+    /// prompt context shows the agent when a memory was marked bad and why.
+    /// </summary>
+    private static string WithSignal(string content, JsonNode m)
+    {
+        int good = ReadInt(m, "good_count");
+        int bad = ReadInt(m, "bad_count");
+        if (good == 0 && bad == 0) return content;
+
+        content += $"  [good {good} / bad {bad}]";
+        var notes = m["feedback_notes"]?.AsArray();
+        if (notes is not null)
+        {
+            foreach (var note in notes)
+            {
+                if (note is null) continue;
+                if (note["verdict"]?.GetValue<string>() == "bad")
+                {
+                    var reason = note["reason"]?.GetValue<string>();
+                    if (!string.IsNullOrEmpty(reason))
+                        content += $" (bad: \"{reason}\")";
+                }
+            }
+        }
+        return content;
+    }
+
+    private static string HashKey(string content)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(content));
+        return "mem-" + Convert.ToHexString(hash)[..16].ToLowerInvariant();
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+        => values.FirstOrDefault(v => !string.IsNullOrEmpty(v));
+
+    private static int ReadInt(JsonNode node, string key)
+    {
+        var v = node[key];
+        if (v is null) return 0;
+        try { return v.GetValue<int>(); }
+        catch { try { return (int)v.GetValue<double>(); } catch { return 0; } }
+    }
+
+    private static double ReadDouble(JsonNode node, string key)
+    {
+        var v = node[key];
+        if (v is null) return 0.0;
+        try { return v.GetValue<double>(); }
+        catch { return 0.0; }
+    }
+
+    private static string Query(params (string Key, string? Value)[] pairs)
+    {
+        var parts = pairs
+            .Where(p => !string.IsNullOrEmpty(p.Value))
+            .Select(p => $"{Uri.EscapeDataString(p.Key)}={Uri.EscapeDataString(p.Value!)}")
+            .ToList();
+        return parts.Count == 0 ? "" : "?" + string.Join("&", parts);
+    }
+
+    public void Dispose()
+    {
+        if (_ownsClient) _client.Dispose();
+    }
+}
+
+/// <summary>
+/// Signed good/bad capability URLs for a memory, minted via
+/// <see cref="OCGMemoryStore.GetFeedbackLinks"/>. Delivered to a human out-of-band;
+/// never shown to the agent's LLM.
+/// </summary>
+public sealed record FeedbackLinks(string? GoodUrl, string? BadUrl, string? ExpiresAt);
+
+/// <summary>Structured output for the conversation summarizer agent.</summary>
+public sealed class MemorySummary
+{
+    /// <summary>One short paragraph: what happened / what was learned.</summary>
+    public string Summary { get; init; } = "";
+    /// <summary>Durable, reusable facts about the user or task (no chit-chat).</summary>
+    public List<string> Facts { get; init; } = [];
+    /// <summary>Short topical tags.</summary>
+    public List<string> Tags { get; init; } = [];
+}
+
+/// <summary>
+/// Handed to an agent's <see cref="Agent.FeedbackSink"/> after a conversation memory
+/// is saved. Carries the distilled summary plus the signed capability URLs a human can
+/// click to mark the memory good/bad. The integrator routes these out-of-band (e.g.
+/// posts them into a Zendesk ticket). These URLs are never shown to the agent's LLM.
+/// </summary>
+public sealed class FeedbackEvent
+{
+    public string MemoryKey { get; init; } = "";
+    public string Summary { get; init; } = "";
+    public List<string> Facts { get; init; } = [];
+    public List<string> Tags { get; init; } = [];
+    public string? GoodUrl { get; init; }
+    public string? BadUrl { get; init; }
+    public string? ExpiresAt { get; init; }
+    public string? Agent { get; init; }
+    public string? User { get; init; }
+    public string? SessionId { get; init; }
+}
+
+/// <summary>
+/// Conversation summarization helpers (Claude-style distillation). The server-side
+/// compiler builds an equivalent summarizer from the agent's <c>summaryModel</c>; this
+/// mirror is exposed for cross-SDK parity and manual summarization.
+/// </summary>
+public static class OCGMemory
+{
+    public const string MemorySummarizerInstructions =
+        "You distill a conversation into a durable memory. Read the transcript and " +
+        "extract only reusable, durable facts about the user, their preferences, and " +
+        "the task — the kind of thing worth remembering for next time. Ignore greetings, " +
+        "filler, and one-off details. Write a one-paragraph summary, a short list of " +
+        "facts, and a few topical tags. Be concise and concrete.";
+
+    /// <summary>
+    /// Build the internal agent that summarizes a conversation into a memory. It uses
+    /// <see cref="MemorySummary"/> structured output and is intentionally created
+    /// WITHOUT <see cref="Agent.SemanticMemory"/> so the post-run save hook skips it
+    /// (no recursion).
+    /// </summary>
+    public static Agent BuildMemorySummarizer(string model, string name = "__memory_summarizer")
+        => new(name)
+        {
+            Model = model,
+            Instructions = MemorySummarizerInstructions,
+            OutputType = typeof(MemorySummary),
+            MaxTurns = 1,
+        };
+}

--- a/Conductor.AI/SemanticMemory.cs
+++ b/Conductor.AI/SemanticMemory.cs
@@ -116,6 +116,10 @@ public sealed class SemanticMemory(MemoryStore? store = null, int maxResults = 5
     public int MaxResults { get; } = maxResults;
     public string? SessionId { get; } = sessionId;
 
+    /// <summary>The backing store. Read by the serializer to detect an OCG-backed
+    /// store (<see cref="OCGMemoryStore"/>) and emit its <c>longTermMemory</c> config.</summary>
+    public MemoryStore Store => _store;
+
     /// <summary>Add a memory entry. Returns the entry ID.</summary>
     public string Add(string content, Dictionary<string, object>? metadata = null)
     {

--- a/Conductor.AI/WorkerManager.cs
+++ b/Conductor.AI/WorkerManager.cs
@@ -410,6 +410,7 @@ internal sealed class WorkerManager : IAsyncDisposable
         foreach (var tool in agent.Tools)
             RegisterGuardrails(tool.Guardrails, domain);
         RegisterCallbacks(agent, domain);
+        RegisterFeedbackSink(agent, domain);
 
         // Local code execution worker — the server adds an execute_code tool to
         // the agent when LocalCodeExecution=true (or CodeExecution is set), but
@@ -586,6 +587,63 @@ internal sealed class WorkerManager : IAsyncDisposable
                 return System.Threading.Tasks.Task.FromResult<object?>(new Dictionary<string, object>());
             }, domain: domain));
         }
+    }
+
+    private void RegisterFeedbackSink(Agent agent, string? domain = null)
+    {
+        // Long-term (OCG) memory feedback_sink — the compiled server-side memory path
+        // emits a SIMPLE task (see AgentConfigSerializer.feedbackSink) that, after
+        // saving a conversation memory and minting the signed good/bad capability URLs,
+        // invokes this worker with the FeedbackEvent fields. The worker rebuilds a
+        // FeedbackEvent and hands it to the user's callback for out-of-band delivery.
+        // Best-effort: failures are swallowed so memory never fails the run.
+        if (agent.SemanticMemory?.Store is not OCGMemoryStore) return;
+        var sink = agent.FeedbackSink;
+        if (sink is null) return;
+
+        var taskName = $"{agent.Name}_feedback_sink";
+        _workers.Add(NewLoop(taskName, (args, _) =>
+        {
+            try
+            {
+                var evt = new FeedbackEvent
+                {
+                    MemoryKey = FbString(args, "memory_key"),
+                    Summary = FbString(args, "summary"),
+                    Facts = FbStringList(args, "facts"),
+                    Tags = FbStringList(args, "tags"),
+                    GoodUrl = FbStringOrNull(args, "good_url"),
+                    BadUrl = FbStringOrNull(args, "bad_url"),
+                    ExpiresAt = FbStringOrNull(args, "expires_at"),
+                    Agent = FbStringOrNull(args, "agent"),
+                    User = FbStringOrNull(args, "user"),
+                };
+                sink(evt);
+                return System.Threading.Tasks.Task.FromResult<object?>(
+                    new Dictionary<string, object> { ["delivered"] = true });
+            }
+            catch
+            {
+                return System.Threading.Tasks.Task.FromResult<object?>(
+                    new Dictionary<string, object> { ["delivered"] = false });
+            }
+        }, domain: domain));
+    }
+
+    private static string FbString(Dictionary<string, JsonElement> args, string key)
+        => FbStringOrNull(args, key) ?? "";
+
+    private static string? FbStringOrNull(Dictionary<string, JsonElement> args, string key)
+        => args.TryGetValue(key, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static List<string> FbStringList(Dictionary<string, JsonElement> args, string key)
+    {
+        var list = new List<string>();
+        if (args.TryGetValue(key, out var v) && v.ValueKind == JsonValueKind.Array)
+            foreach (var item in v.EnumerateArray())
+                if (item.ValueKind == JsonValueKind.String)
+                    list.Add(item.GetString() ?? "");
+        return list;
     }
 
     private void RegisterSwarmTransferWorkers(Agent agent, string? domain = null)


### PR DESCRIPTION
Ports the SDK side of the "OCG-backed agent memory" feature from **agentspan-ai/agentspan#298** to the C# SDK. The server-side compiler that consumes the wire config lives in **conductor-oss/conductor** (`agentspan-server`: `LongTermMemoryConfig.java`, `AgentConfig.longTermMemory/feedbackSink`).

## What was ported

- **`OCGMemoryStore`** (`Conductor.AI/OCGMemory.cs`) — a synchronous `MemoryStore` HTTP adapter over the OCG BFF:
  - `Add` → `POST /api/v1/memories`
  - `Search` → `POST /api/v1/memories/search` (folds the human good/bad signal into result content)
  - `Delete` → `DELETE /api/v1/memories/{key}`, `ListAll` → `GET /api/v1/memories`, `Clear` (fan-out)
  - `GetFeedbackLinks` → `POST /api/v1/memories/{key}/feedback-links` (mints signed good/bad capability URLs)
  - Auth via `Authorization: Bearer <token>`; the token is held client-side. Also exposes `MemorySummary`, `FeedbackEvent`, `FeedbackLinks`, and `OCGMemory.BuildMemorySummarizer`.
- **Agent params** (`Conductor.AI/Agent.cs`, + `AgentBuilder` fluent methods): `SemanticMemory`, `MemorySummaryModel`, `FeedbackSink` (`Action<FeedbackEvent>`).
- **Serializer emission** (`Conductor.AI/AgentConfigSerializer.cs`) — the most important piece. When an agent's `SemanticMemory` is backed by an `OCGMemoryStore`, emits:
  - `longTermMemory`: `{ocgUrl, credential, agent, user, scope, maxResults, summaryModel}` — `credential` is a server-resolvable secret NAME (`OCG_PUBLIC_KEY`), never the raw client token; `summaryModel` falls back to the agent's own model.
  - `feedbackSink`: `{taskName: "{name}_feedback_sink"}` when a feedback sink is set.
- **Feedback-sink worker** (`Conductor.AI/WorkerManager.cs`) — registers a `{name}_feedback_sink` worker (analogous to the existing callback/gate workers) so the compiled server path can hand the `FeedbackEvent` (distilled summary + signed good/bad URLs) to the user's `FeedbackSink` for out-of-band delivery. Best-effort. The capability URLs are never surfaced to the agent's LLM.
- **Tests** (`Conductor.AI.Tests/OcgMemoryTests.cs`, xUnit) — store adapter (add posts `value` not `string_value`/`confidence`; search folds good/bad signal; feedback-link route; non-2xx raises; blank url/agent rejected) and serializer emission (present / absent / summaryModel fallback / non-OCG store no-op).
- **Example** `Conductor.AI.Examples/27_OcgMemory` mirroring Python `examples/118_ocg_memory.py`.
- CHANGELOG entry.

## What was skipped

**Client-side pre/post-run memory hooks** from Python `runtime.py` (`_apply_memory_retrieval`, `_maybe_save_conversation_memory`, `_parse_summary_output`) are **not** ported. This SDK has no client-side agent run loop — `AgentRuntime.RunAsync` is control-plane only (it serializes the agent, starts the workflow, and polls the server, which runs the LLM loop). Memory therefore activates entirely through the serialized `longTermMemory` config that the server-side compiler expands into pre-loop retrieval + post-loop distill/save/feedback. The corresponding runtime-hook unit tests were skipped for the same reason.

## C#-specific adaptations

- `OCGMemoryStore` accepts an injectable `HttpClient` for testing (the C# analogue of Python's `httpx.Client` + `MockTransport`); the async `HttpClient` is driven synchronously to satisfy the sync `MemoryStore` interface.
- OCG-backed detection uses a type check (`Store is OCGMemoryStore`) rather than Python's duck-typed `_base` attribute probe.
- `MemoryEntry` is immutable (`init`-only), so `Add` returns the key without mutating the entry.
- `FeedbackLinks` is a typed record; `MemorySummary`/`FeedbackEvent` are plain classes.

## Test results

`dotnet test Conductor.AI.Tests` — **65 passed, 0 failed, 0 skipped** (9 new + 56 pre-existing). The main library and the new example both build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)