### PR TITLE
Log task polling errors at Error level

### DIFF
--- a/Conductor/Client/Worker/WorkflowTaskExecutor.cs
+++ b/Conductor/Client/Worker/WorkflowTaskExecutor.cs
@@ -189,7 +189,7 @@ namespace Conductor.Client.Worker
                 pollStopwatch.Stop();
                 _metrics?.RecordTaskPollTime(_worker.TaskType, pollStopwatch.Elapsed.TotalSeconds, "FAILURE");
                 _metrics?.RecordTaskPollError(_worker.TaskType, e.GetType().Name);
-                _logger.LogTrace(
+                _logger.LogError(
                     $"[{_workerSettings.WorkerId}] Polling error: {e.Message} "
                     + $", taskType: {_worker.TaskType}"
                     + $", domain: {_workerSettings.Domain}"


### PR DESCRIPTION
## What

`WorkflowTaskExecutor.PollTasksAsync` caught polling exceptions, logged them at `Trace`, and swallowed them.

At the default log level this meant polling errors — e.g. a **403 caused by an invalid/unknown API key** — were **silently dismissed**. The worker logged `Started worker` and looked healthy while it never polled successfully, giving no signal that anything was wrong. The failure only became visible if you happened to run at `Trace`.

This changes that single log call to `Error`, so the failure shows up (`fail:`) at the default level without cranking up verbosity. It's consistent with the other catch blocks in the same class (`ProcessTask`, `UpdateTaskAsync`, `Work4Ever`), which already log at `Error`.

## How to test

Run a worker with credentials the server will reject (or point at an unreachable `BasePath`). Previously: nothing at the default level. Now:

```
fail: Conductor.Client.Worker.WorkflowTaskExecutor[0]
      [host] Polling error: Failed to refresh authentication token, taskType: greet, ...
```

## Notes

- Scope is intentionally minimal: visibility only. Retry/backoff behavior is unchanged, so a persistent auth failure still re-logs on every poll — distinguishing fatal (auth) vs transient errors and backing off is a worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)