### PR TITLE
Guardrails: make regex/LLM server-driven, combine custom guardrails per scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sharing that `Configuration`'s token cache. The old bespoke
   `AgentAuthHandler` and its separate token client are deleted; 404s map to
   `AgentNotFoundException`, other non-2xx to `AgentApiException`.
+- Guardrails are server-driven: `RegexGuardrail.Create` / `LLMGuardrail.Create`
+  are data-only, evaluated by the Conductor server itself — no worker,
+  `HttpClient`, or API key needed client-side. `LLMGuardrail.Create` drops
+  its `apiKey` parameter. Custom `[Guardrail]` methods still run your own
+  code, now combined into one worker per agent/tool scope
+  (`{scope}_output_guardrail`) instead of one worker per guardrail.
 - SSE streaming hardened: sources its auth header from
   `Configuration.AccessToken` on every (re)connect, tracks `Last-Event-ID`
   across drops with bounded backoff, and throws `SSEUnavailableException`

--- a/Conductor.AI.E2eTests/Suite3_Guardrails.cs
+++ b/Conductor.AI.E2eTests/Suite3_Guardrails.cs
@@ -240,6 +240,8 @@ public sealed class Suite3_Guardrails
         Assert.True(host.CheckCount > 0, "Expected the guardrail to run at least once.");
         Assert.True(result.IsFailed || result.Status == Status.Terminated,
             $"Expected escalation to fail the run, got {result.Status}.");
+        Assert.False(string.IsNullOrEmpty(result.Error),
+            "Expected the guardrail failure message in Error, got null/empty.");
     }
 
     // ── 3.8  Tool-level RETRY escalates to RAISE after maxRetries ───────

--- a/Conductor.AI.E2eTests/Suite3_Guardrails.cs
+++ b/Conductor.AI.E2eTests/Suite3_Guardrails.cs
@@ -10,11 +10,13 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-// Suite 3 — Guardrail execution: verify guardrail function body runs and
-// that the agent status reflects the guardrail outcome.
+// Suite 3 — Guardrail execution: verify guardrail function bodies run, that
+// server-evaluated (regex/llm) guardrails register no local worker at all,
+// and that retry escalation actually fails a run instead of silently
+// exhausting max_turns.
 //
-// Validation: Interlocked counters on the guardrail function body.
-// We do NOT assert on LLM output text.
+// Validation: Interlocked counters on the guardrail function body plus
+// AgentResult.Status checks. We do NOT assert on LLM output text.
 //
 // CLAUDE.md rule: no LLM for validation; write test → make it fail → confirm failure.
 
@@ -84,10 +86,12 @@ public sealed class Suite3_Guardrails
         Assert.True(result.IsSuccess, $"Agent failed unexpectedly: {result.Error}");
     }
 
-    // ── 3.3  Regex guardrail blocks PII-like content ─────────────────────
+    // ── 3.3  Custom guardrail with a .NET regex check blocks PII ─────────
+    // custom guardrail using System.Text.RegularExpressions in its handler —
+    // not the server-evaluated RegexGuardrail.Create (that's 3.5)
 
     [SkippableFact]
-    public async Task RegexGuardrail_FunctionBodyExecutes()
+    public async Task CustomGuardrail_DotNetRegexCheck_BlocksPii()
     {
         _fixture.RequireServer();
 
@@ -117,30 +121,162 @@ public sealed class Suite3_Guardrails
             $"Unexpected status: {result.Status}");
     }
 
-    // ── 3.4  Tool-level guardrail: wrapper executes before tool ──────────
+    // ── 3.4  Tool-level guardrail actually blocks a violating call ───────
+    // real GuardrailDef attached via WithGuardrails; run must fail on violation
 
     [SkippableFact]
-    public async Task ToolGuardrail_WrapperExecutesBeforeTool()
+    public async Task ToolGuardrail_BlocksViolatingCall_RunFails()
     {
         _fixture.RequireServer();
 
-        var host = new S3ToolGuardrailHost();
-        var tools = ToolRegistry.FromInstance(host);
+        var guardHost = new S3ToolGuardrailDefHost();
+        var guardrail = GuardrailRegistry.FromInstance(guardHost).Single();
 
-        var agent = new Agent("s3_tool_guardrail")
+        var dbHost = new S3DbToolHost();
+        var tools = ToolRegistry.FromInstance(dbHost)
+            .Select(t => t.Name == "run_query" ? t.WithGuardrails(guardrail) : t)
+            .ToList();
+
+        var agent = new Agent("s3_tool_guardrail_raise")
         {
             Model = Settings.LlmModel,
-            Instructions = "Use run_query to answer database questions.",
+            Instructions = "You must call the run_query tool with the exact argument "
+                + "query=\"DROP TABLE users\" and nothing else.",
             Tools = tools,
         };
 
         await using var runtime = new AgentRuntime();
-        // Safe query — tool must execute
-        var result = await runtime.RunAsync(agent, "Find all users in the database.");
+        var result = await runtime.RunAsync(agent, "Run the query as instructed.");
 
-        Assert.True(result.IsSuccess, $"Agent failed: {result.Error}");
-        Assert.True(host.QueryCallCount > 0,
-            "Expected run_query to be called at least once.");
+        Assert.True(guardHost.CheckCount > 0,
+            $"Expected the tool guardrail to be invoked. CheckCount={guardHost.CheckCount}");
+        Assert.True(result.IsFailed || result.Status == Status.Terminated,
+            $"Expected the run to fail after the tool guardrail raised, got {result.Status}.");
+        Assert.Equal(0, dbHost.QueryCallCount);  // blocked pre-execution — the tool body never ran
+    }
+
+    // ── 3.5  RegexGuardrail.Create is server-evaluated: no local worker ──
+
+    [SkippableFact]
+    public async Task RegexGuardrail_ServerEvaluated_NoLocalWorkerRegistered()
+    {
+        _fixture.RequireServer();
+
+        var guard = RegexGuardrail.Create(
+            pattern: @"\d{3}-\d{2}-\d{4}",
+            name: "no_ssn_server_side",
+            message: "Response must not contain a social security number.",
+            onFail: OnFail.Raise);
+
+        var agent = new Agent("s3_regex_server_evaluated")
+        {
+            Model = Settings.LlmModel,
+            Instructions = "Answer briefly.",
+            Guardrails = [guard],
+        };
+
+        await using var runtime = new AgentRuntime();
+        var result = await runtime.RunAsync(agent, "Say hello.");
+
+        // Server-evaluated guardrails carry no local Handler and register no
+        // worker — the Conductor server compiles and runs them itself as an
+        // INLINE GraalJS task.
+        Assert.Null(runtime.WorkerForTesting("s3_regex_server_evaluated_output_guardrail"));
+        Assert.Null(runtime.WorkerForTesting("no_ssn_server_side"));
+        Assert.True(result.IsSuccess || result.IsFailed, $"Unexpected status: {result.Status}");
+    }
+
+    // ── 3.6  LLMGuardrail.Create is server-evaluated: no local worker ────
+
+    [SkippableFact]
+    public async Task LlmGuardrail_ServerEvaluated_NoLocalWorkerRegistered()
+    {
+        _fixture.RequireServer();
+
+        var guard = LLMGuardrail.Create(
+            model: Settings.LlmModel,
+            policy: "Reject any response that contains a number.",
+            name: "no_numbers_server_side",
+            onFail: OnFail.Raise);
+
+        var agent = new Agent("s3_llm_server_evaluated")
+        {
+            Model = Settings.LlmModel,
+            Instructions = "Answer briefly.",
+            Guardrails = [guard],
+        };
+
+        await using var runtime = new AgentRuntime();
+        var result = await runtime.RunAsync(agent, "What is 2+2? Just give the number.");
+
+        Assert.Null(runtime.WorkerForTesting("s3_llm_server_evaluated_output_guardrail"));
+        Assert.Null(runtime.WorkerForTesting("no_numbers_server_side"));
+        Assert.True(result.IsSuccess || result.IsFailed, $"Unexpected status: {result.Status}");
+    }
+
+    // ── 3.7  Agent-level RETRY escalates to RAISE after maxRetries ───────
+    // always-fail guardrail, maxRetries=1 → run must fail before the turn cap;
+    // COMPLETED would mean the loop exhausted max_turns without escalating
+
+    [SkippableFact]
+    public async Task AgentGuardrail_RetryEscalatesToRaise_AfterMaxRetries()
+    {
+        _fixture.RequireServer();
+
+        var host = new S3AlwaysFailGuardrailHost();
+        var guardrails = GuardrailRegistry.FromInstance(host);
+
+        var agent = new Agent("s3_retry_escalation")
+        {
+            Model = Settings.LlmModel,
+            Instructions = "Answer briefly.",
+            Guardrails = guardrails,
+            MaxTurns = 3,
+        };
+
+        await using var runtime = new AgentRuntime();
+        var result = await runtime.RunAsync(agent, "Say hello.");
+
+        Assert.True(host.CheckCount > 0, "Expected the guardrail to run at least once.");
+        Assert.True(result.IsFailed || result.Status == Status.Terminated,
+            $"Expected escalation to fail the run, got {result.Status}.");
+    }
+
+    // ── 3.8  Tool-level RETRY escalates to RAISE after maxRetries ───────
+    // same as 3.7 for a tool guardrail; env-gated — the server hardcodes the
+    // tool-guardrail iteration ref to "1", so retry never escalates today.
+    // set E2E_TOOL_GUARDRAIL_ESCALATION=true once the server fix ships
+
+    [SkippableFact]
+    public async Task ToolGuardrail_RetryEscalatesToRaise_AfterMaxRetries()
+    {
+        _fixture.RequireServer();
+        Skip.IfNot(
+            Environment.GetEnvironmentVariable("E2E_TOOL_GUARDRAIL_ESCALATION") == "true",
+            "Tool-guardrail retry escalation is disabled server-side — set "
+            + "E2E_TOOL_GUARDRAIL_ESCALATION=true once the server fix ships.");
+
+        var guardHost = new S3AlwaysFailToolGuardrailHost();
+        var guardrail = GuardrailRegistry.FromInstance(guardHost).Single();
+
+        var tools = ToolRegistry.FromInstance(new S3DbToolHost())
+            .Select(t => t.Name == "run_query" ? t.WithGuardrails(guardrail) : t)
+            .ToList();
+
+        var agent = new Agent("s3_tool_retry_escalation")
+        {
+            Model = Settings.LlmModel,
+            Instructions = "Call run_query with any query to answer database questions.",
+            Tools = tools,
+            MaxTurns = 3,
+        };
+
+        await using var runtime = new AgentRuntime();
+        var result = await runtime.RunAsync(agent, "Look up all users.");
+
+        Assert.True(guardHost.CheckCount > 0, "Expected the tool guardrail to run at least once.");
+        Assert.True(result.IsFailed || result.Status == Status.Terminated,
+            $"Expected escalation to fail the run, got {result.Status}.");
     }
 }
 
@@ -201,10 +337,8 @@ internal sealed class S3PiiToolHost
     };
 }
 
-internal sealed class S3ToolGuardrailHost
+internal sealed class S3DbToolHost
 {
-    private static readonly Regex DangerPattern = new(@"DROP\s+TABLE|DELETE\s+FROM", RegexOptions.IgnoreCase);
-
     private int _queryCalls;
     public int QueryCallCount => _queryCalls;
 
@@ -212,8 +346,49 @@ internal sealed class S3ToolGuardrailHost
     public string RunQuery(string query)
     {
         Interlocked.Increment(ref _queryCalls);
-        if (DangerPattern.IsMatch(query))
-            return "Blocked: destructive SQL detected.";
-        return $"Results: [('Alice', 30), ('Bob', 25)]";
+        return "Results: [('Alice', 30), ('Bob', 25)]";
+    }
+}
+
+internal sealed class S3ToolGuardrailDefHost
+{
+    private static readonly Regex DangerPattern = new(@"DROP\s+TABLE|DELETE\s+FROM", RegexOptions.IgnoreCase);
+
+    private int _checkCount;
+    public int CheckCount => _checkCount;
+
+    [Guardrail("no_drop_table", Position = Position.Input, OnFail = OnFail.Raise)]
+    public GuardrailResult NoDestructiveSql(string content)
+    {
+        Interlocked.Increment(ref _checkCount);
+        if (DangerPattern.IsMatch(content))
+            return new GuardrailResult(false, "Destructive SQL detected in tool call.");
+        return new GuardrailResult(true);
+    }
+}
+
+internal sealed class S3AlwaysFailGuardrailHost
+{
+    private int _checkCount;
+    public int CheckCount => _checkCount;
+
+    [Guardrail(Position = Position.Output, OnFail = OnFail.Retry, MaxRetries = 1)]
+    public GuardrailResult AlwaysFail(string content)
+    {
+        Interlocked.Increment(ref _checkCount);
+        return new GuardrailResult(false, "always fails, to force escalation");
+    }
+}
+
+internal sealed class S3AlwaysFailToolGuardrailHost
+{
+    private int _checkCount;
+    public int CheckCount => _checkCount;
+
+    [Guardrail(Position = Position.Input, OnFail = OnFail.Retry, MaxRetries = 1)]
+    public GuardrailResult AlwaysFail(string content)
+    {
+        Interlocked.Increment(ref _checkCount);
+        return new GuardrailResult(false, "always fails, to force escalation");
     }
 }

--- a/Conductor.AI.Examples/22_LlmGuardrails/Program.cs
+++ b/Conductor.AI.Examples/22_LlmGuardrails/Program.cs
@@ -12,15 +12,14 @@
  */
 // LLM Guardrails — AI-powered content safety evaluation.
 //
-// LLMGuardrail.Create() uses a separate LLM to evaluate whether agent
-// output meets a defined policy.  The guardrail LLM receives the policy
-// + content and must respond with {"passed": true/false, "reason": "..."}.
+// LLMGuardrail.Create() is data-only: the Conductor server evaluates the
+// policy against the content using its own configured LLM providers.
+// No worker process or API key is needed on the client side.
 //
 // Requirements:
 //   - Agentspan server with LLM support
 //   - AGENTSPAN_SERVER_URL=http://localhost:8080/api in environment
 //   - AGENTSPAN_LLM_MODEL set in environment
-//   - OPENAI_API_KEY set in environment (for the guardrail LLM call)
 
 using Conductor.AI;
 using Conductor.AI.Examples;

--- a/Conductor.AI.Examples/90_GuardrailE2eTests/Program.cs
+++ b/Conductor.AI.Examples/90_GuardrailE2eTests/Program.cs
@@ -52,7 +52,10 @@
 //   - Agentspan server with LLM support
 //   - AGENTSPAN_SERVER_URL=http://localhost:8080/api in environment
 //   - AGENTSPAN_LLM_MODEL set in environment
-//   - OPENAI_API_KEY set in environment (for LLM guardrails)
+//
+// Regex/LLM guardrails are evaluated server-side (no client worker, no API
+// key needed on this process) — rows noted "in worker" below describe
+// custom guardrails only.
 
 using Conductor.AI;
 using Conductor.AI.Examples;

--- a/Conductor.AI.Tests/AgentStatusMappingTests.cs
+++ b/Conductor.AI.Tests/AgentStatusMappingTests.cs
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+// The server's /agent/{id}/status response has no "error"/"reason" field — only
+// "reasonForIncompletion". AgentResult.Error and AgentStatus.Reason used to read
+// the wrong key and were always null on failed/terminated runs.
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Conductor.Client;
+using RestSharp;
+using Xunit;
+
+namespace Conductor.AI.Tests;
+
+public sealed class AgentStatusMappingTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, (HttpStatusCode Status, string Body)> _respond;
+        public StubHandler(Func<HttpRequestMessage, (HttpStatusCode, string)> respond) => _respond = respond;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var (status, body) = _respond(request);
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private static Configuration BuildConfig(Func<HttpRequestMessage, (HttpStatusCode, string)> respond)
+    {
+        var configuration = new Configuration { BasePath = "http://server/api" };
+        configuration.ApiClient.RestClient = new RestClient(new RestClientOptions("http://server/api")
+        {
+            ConfigureMessageHandler = _ => new StubHandler(respond),
+        });
+        return configuration;
+    }
+
+    private static (HttpStatusCode, string) RouteStatusAndExecution(
+        HttpRequestMessage request, string statusBody, string executionBody = "{}")
+    {
+        var path = request.RequestUri!.AbsolutePath;
+        return path.EndsWith("/status")
+            ? (HttpStatusCode.OK, statusBody)
+            : (HttpStatusCode.OK, executionBody);
+    }
+
+    // ── AgentRuntime.GetStatusAsync ──────────────────────────────────────
+
+    [Fact]
+    public async Task GetStatusAsync_Failed_SurfacesReasonForIncompletion()
+    {
+        var config = BuildConfig(req => RouteStatusAndExecution(req, """
+            {"executionId":"e1","status":"FAILED","isComplete":true,"isRunning":false,
+             "isWaiting":false,"reasonForIncompletion":"Guardrail 'content_safety' failed: unsafe content"}
+            """));
+
+        using var runtime = new AgentRuntime(config);
+        var status = await runtime.GetStatusAsync("e1");
+
+        Assert.Equal("Guardrail 'content_safety' failed: unsafe content", status.Reason);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_Completed_ReasonStaysNull()
+    {
+        var config = BuildConfig(req => RouteStatusAndExecution(req, """
+            {"executionId":"e1","status":"COMPLETED","isComplete":true,"isRunning":false,"isWaiting":false}
+            """));
+
+        using var runtime = new AgentRuntime(config);
+        var status = await runtime.GetStatusAsync("e1");
+
+        Assert.Null(status.Reason);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_PopulatesOutput()
+    {
+        var config = BuildConfig(req => RouteStatusAndExecution(req, """
+            {"executionId":"e1","status":"COMPLETED","isComplete":true,"isRunning":false,
+             "isWaiting":false,"output":{"result":"hello"}}
+            """));
+
+        using var runtime = new AgentRuntime(config);
+        var status = await runtime.GetStatusAsync("e1");
+
+        Assert.NotNull(status.Output);
+    }
+
+    // ── AgentHandle.WaitAsync (the RunAsync/PrintResult path) ────────────
+
+    [Fact]
+    public async Task WaitAsync_Failed_SurfacesReasonForIncompletionAsError()
+    {
+        var config = BuildConfig(req => RouteStatusAndExecution(req, """
+            {"executionId":"e1","status":"FAILED","isComplete":true,"isRunning":false,
+             "isWaiting":false,"reasonForIncompletion":"Guardrail 'content_safety' failed: unsafe content"}
+            """));
+
+        var handle = new AgentHandle("e1", new OrkesAgentClient(config));
+        var result = await handle.WaitAsync();
+
+        Assert.Equal(Status.Failed, result.Status);
+        Assert.Equal("Guardrail 'content_safety' failed: unsafe content", result.Error);
+    }
+
+    [Fact]
+    public async Task WaitAsync_Completed_ErrorStaysNull()
+    {
+        var config = BuildConfig(req => RouteStatusAndExecution(req, """
+            {"executionId":"e1","status":"COMPLETED","isComplete":true,"isRunning":false,
+             "isWaiting":false,"output":{"result":"hello"}}
+            """));
+
+        var handle = new AgentHandle("e1", new OrkesAgentClient(config));
+        var result = await handle.WaitAsync();
+
+        Assert.Equal(Status.Completed, result.Status);
+        Assert.Null(result.Error);
+    }
+}

--- a/Conductor.AI.Tests/AgentStatusMappingTests.cs
+++ b/Conductor.AI.Tests/AgentStatusMappingTests.cs
@@ -53,11 +53,15 @@ public sealed class AgentStatusMappingTests
 
     private static (HttpStatusCode, string) RouteStatusAndExecution(
         HttpRequestMessage request, string statusBody, string executionBody = "{}")
+        => Route(request, statusBody, executionBody, "{}");
+
+    private static (HttpStatusCode, string) Route(
+        HttpRequestMessage request, string statusBody, string executionBody, string workflowBody)
     {
         var path = request.RequestUri!.AbsolutePath;
-        return path.EndsWith("/status")
-            ? (HttpStatusCode.OK, statusBody)
-            : (HttpStatusCode.OK, executionBody);
+        if (path.EndsWith("/status")) return (HttpStatusCode.OK, statusBody);
+        if (path.Contains("/execution/")) return (HttpStatusCode.OK, executionBody);
+        return (HttpStatusCode.OK, workflowBody);
     }
 
     // ── AgentRuntime.GetStatusAsync ──────────────────────────────────────
@@ -133,5 +137,72 @@ public sealed class AgentStatusMappingTests
 
         Assert.Equal(Status.Completed, result.Status);
         Assert.Null(result.Error);
+    }
+
+    // ── Java parity: Error only read on non-Completed status ─────────────
+
+    [Fact]
+    public async Task WaitAsync_CompletedWithStrayReasonForIncompletion_ErrorIgnored()
+    {
+        // Defensive gate matching Java's `if (status != COMPLETED)` — even if the
+        // server ever sent a stray reasonForIncompletion on a completed run, it
+        // must not leak into Error.
+        var config = BuildConfig(req => RouteStatusAndExecution(req, """
+            {"executionId":"e1","status":"COMPLETED","isComplete":true,"isRunning":false,
+             "isWaiting":false,"reasonForIncompletion":"should be ignored","output":{"result":"hello"}}
+            """));
+
+        var handle = new AgentHandle("e1", new OrkesAgentClient(config));
+        var result = await handle.WaitAsync();
+
+        Assert.Null(result.Error);
+    }
+
+    // ── Java parity: ToolCalls aggregated from workflow tasks ────────────
+
+    [Fact]
+    public async Task WaitAsync_ExtractsToolCallsFromWorkflowTasks()
+    {
+        var config = BuildConfig(req => Route(
+            req,
+            statusBody: """
+                {"executionId":"e1","status":"COMPLETED","isComplete":true,"isRunning":false,"isWaiting":false}
+                """,
+            executionBody: "{}",
+            workflowBody: """
+                {"tasks":[
+                    {"taskType":"echo","referenceTaskName":"call_echo_1",
+                     "inputData":{"query":"hello","_internal":"drop me","ctx":"drop me too"},
+                     "outputData":{"result":"echoed: hello"}},
+                    {"taskType":"LLM_CHAT_COMPLETE","referenceTaskName":"llm_1",
+                     "inputData":{},"outputData":{"promptTokens":10}}
+                ]}
+                """));
+
+        var handle = new AgentHandle("e1", new OrkesAgentClient(config));
+        var result = await handle.WaitAsync();
+
+        var toolCall = Assert.Single(result.ToolCalls!);
+        Assert.Equal("echo", toolCall["name"]);
+        var args = Assert.IsType<Dictionary<string, object>>(toolCall["args"]);
+        Assert.Equal(["query"], args.Keys);
+        Assert.Equal("echoed: hello", toolCall["result"]!.ToString());
+    }
+
+    [Fact]
+    public async Task WaitAsync_NoMatchingTasks_ToolCallsStaysNull()
+    {
+        var config = BuildConfig(req => Route(
+            req,
+            statusBody: """
+                {"executionId":"e1","status":"COMPLETED","isComplete":true,"isRunning":false,"isWaiting":false}
+                """,
+            executionBody: "{}",
+            workflowBody: """{"tasks":[]}"""));
+
+        var handle = new AgentHandle("e1", new OrkesAgentClient(config));
+        var result = await handle.WaitAsync();
+
+        Assert.Null(result.ToolCalls);
     }
 }

--- a/Conductor.AI.Tests/GuardrailTests.cs
+++ b/Conductor.AI.Tests/GuardrailTests.cs
@@ -83,4 +83,114 @@ public class GuardrailTests
         var g = Guardrail.External("g", position: Position.Output, onFail: OnFail.Human);
         Assert.Equal(OnFail.Human, g.OnFail);
     }
+
+    // ── GuardrailDef.Validate matrix — every rule x every construction path ──
+    // Closes the bypass where GuardrailRegistry.FromInstance and direct init
+    // skipped validation entirely.
+
+    [Fact]
+    public void Validate_rejects_blank_name_for_external()
+    {
+        Assert.Throws<ArgumentException>(() => Guardrail.External("   "));
+    }
+
+    [Fact]
+    public void Validate_rejects_blank_name_for_regex()
+    {
+        Assert.Throws<ArgumentException>(() => RegexGuardrail.Create("x", name: "  "));
+    }
+
+    [Fact]
+    public void Validate_rejects_blank_name_for_llm()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            LLMGuardrail.Create("openai/gpt-4o-mini", "no bad stuff", name: ""));
+    }
+
+    [Fact]
+    public void Validate_rejects_blank_name_from_attribute_path()
+    {
+        var host = new BlankNameGuardrailHost();
+        Assert.Throws<ArgumentException>(() => GuardrailRegistry.FromInstance(host));
+    }
+
+    [Fact]
+    public void Validate_rejects_negative_max_retries_for_external()
+    {
+        Assert.Throws<ArgumentException>(() => Guardrail.External("g", maxRetries: -1));
+    }
+
+    [Fact]
+    public void Validate_rejects_negative_max_retries_for_regex()
+    {
+        Assert.Throws<ArgumentException>(() => RegexGuardrail.Create("x", maxRetries: -1));
+    }
+
+    [Fact]
+    public void Validate_rejects_negative_max_retries_for_llm()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            LLMGuardrail.Create("openai/gpt-4o-mini", "no bad stuff", maxRetries: -1));
+    }
+
+    [Fact]
+    public void Validate_rejects_negative_max_retries_from_attribute_path()
+    {
+        var host = new NegativeMaxRetriesGuardrailHost();
+        Assert.Throws<ArgumentException>(() => GuardrailRegistry.FromInstance(host));
+    }
+
+    [Fact]
+    public void Validate_rejects_empty_patterns_for_regex()
+    {
+        Assert.Throws<ArgumentException>(() => RegexGuardrail.Create([]));
+    }
+
+    [Fact]
+    public void Validate_rejects_invalid_mode_for_regex()
+    {
+        Assert.Throws<ArgumentException>(() => RegexGuardrail.Create("x", mode: "deny"));
+    }
+
+    [Fact]
+    public void Validate_rejects_blank_model_for_llm()
+    {
+        Assert.Throws<ArgumentException>(() => LLMGuardrail.Create("", "no bad stuff"));
+    }
+
+    [Fact]
+    public void Validate_rejects_blank_policy_for_llm()
+    {
+        Assert.Throws<ArgumentException>(() => LLMGuardrail.Create("openai/gpt-4o-mini", ""));
+    }
+
+    [Fact]
+    public void Validate_accepts_well_formed_regex_guardrail()
+    {
+        var g = RegexGuardrail.Create(["a", "b"], mode: "allow", name: "ok");
+        Assert.Equal("ok", g.Name);
+        Assert.Equal(new[] { "a", "b" }, g.Patterns);
+        Assert.Equal("allow", g.Mode);
+    }
+
+    [Fact]
+    public void Validate_accepts_well_formed_llm_guardrail()
+    {
+        var g = LLMGuardrail.Create("openai/gpt-4o-mini", "reject harmful content", maxTokens: 128);
+        Assert.Equal("openai/gpt-4o-mini", g.Model);
+        Assert.Equal("reject harmful content", g.Policy);
+        Assert.Equal(128, g.MaxTokens);
+    }
+
+    private sealed class BlankNameGuardrailHost
+    {
+        [Guardrail(Name = "  ")]
+        public GuardrailResult Check(string content) => new(true);
+    }
+
+    private sealed class NegativeMaxRetriesGuardrailHost
+    {
+        [Guardrail(MaxRetries = -1)]
+        public GuardrailResult Check(string content) => new(true);
+    }
 }

--- a/Conductor.AI.Tests/GuardrailTests.cs
+++ b/Conductor.AI.Tests/GuardrailTests.cs
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+using System.Linq;
 using Conductor.AI;
 using Xunit;
 
@@ -31,10 +32,58 @@ public class GuardrailTests
         Assert.Null(g.Handler);          // referenced-by-name, no local func
         Assert.True(g.External);
 
-        var json = AgentConfigSerializer.SerializeGuardrail(g);
+        var json = AgentConfigSerializer.SerializeGuardrail(g, "s3_pii_guardrail");
         Assert.Equal("external", json["guardrailType"]!.GetValue<string>());
-        Assert.Equal("pii_remote", json["taskName"]!.GetValue<string>());
         Assert.Equal("pii_remote", json["name"]!.GetValue<string>());
+        // External guardrails dispatch on `name`, not `taskName` — the server's
+        // compileExternalGuardrail names the SIMPLE task from guard.getName().
+        Assert.Null(json["taskName"]);
+    }
+
+    // ── Server-driven serialization: regex/llm carry real data, no taskName ──
+
+    [Fact]
+    public void Regex_serializes_as_regex_with_patterns_no_taskname()
+    {
+        var g = RegexGuardrail.Create(["\\S+@\\S+"], mode: "block", name: "no_pii", message: "no emails");
+        var json = AgentConfigSerializer.SerializeGuardrail(g, "support_agent");
+
+        Assert.Equal("regex", json["guardrailType"]!.GetValue<string>());
+        Assert.Null(json["taskName"]);
+        Assert.Equal("block", json["mode"]!.GetValue<string>());
+        Assert.Equal("no emails", json["message"]!.GetValue<string>());
+        Assert.Equal(1, json["patterns"]!.AsArray().Count);
+        Assert.Equal("\\S+@\\S+", json["patterns"]![0]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Llm_serializes_as_llm_with_model_and_policy_no_taskname()
+    {
+        var g = LLMGuardrail.Create("anthropic/claude-sonnet-4-6", "no bad stuff", maxTokens: 128);
+        var json = AgentConfigSerializer.SerializeGuardrail(g, "support_agent");
+
+        Assert.Equal("llm", json["guardrailType"]!.GetValue<string>());
+        Assert.Null(json["taskName"]);
+        Assert.Equal("anthropic/claude-sonnet-4-6", json["model"]!.GetValue<string>());
+        Assert.Equal("no bad stuff", json["policy"]!.GetValue<string>());
+        Assert.Equal(128, json["maxTokens"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void Custom_serializes_with_scope_prefixed_taskname()
+    {
+        var host = new CustomGuardrailHost();
+        var g = GuardrailRegistry.FromInstance(host).Single();
+        var json = AgentConfigSerializer.SerializeGuardrail(g, "support_agent");
+
+        Assert.Equal("custom", json["guardrailType"]!.GetValue<string>());
+        Assert.Equal("support_agent_output_guardrail", json["taskName"]!.GetValue<string>());
+    }
+
+    private sealed class CustomGuardrailHost
+    {
+        [Guardrail("check")]
+        public GuardrailResult Check(string content) => new(true);
     }
 
     [Fact]

--- a/Conductor.AI.Tests/GuardrailWorkerTests.cs
+++ b/Conductor.AI.Tests/GuardrailWorkerTests.cs
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+// GuardrailHandlerFactory: combined per-scope handler for local (custom) guardrails.
+// Registration: one combined worker per scope ({scope}_output_guardrail), dedup
+// against double registration.
+
+using System.Text.Json;
+using Conductor.Client;
+using Xunit;
+
+namespace Conductor.AI.Tests;
+
+public sealed class GuardrailWorkerTests
+{
+    private static Dictionary<string, JsonElement> Args(string content, int? iteration = null)
+    {
+        var dict = new Dictionary<string, JsonElement> { ["content"] = JsonSerializer.SerializeToElement(content) };
+        if (iteration is not null) dict["iteration"] = JsonSerializer.SerializeToElement(iteration.Value);
+        return dict;
+    }
+
+    private static GuardrailDef Custom(
+        string name, OnFail onFail, Func<string, GuardrailResult> fn, int maxRetries = 3) => new()
+    {
+        Name = name,
+        OnFail = onFail,
+        MaxRetries = maxRetries,
+        Handler = content => Task.FromResult(fn(content)),
+    };
+
+    // ── handler factory ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Factory_EvaluatesInOrder_FirstFailureWins()
+    {
+        var calls = new List<string>();
+        var first = Custom("first", OnFail.Raise, c => { calls.Add("first"); return new GuardrailResult(false, "bad"); });
+        var second = Custom("second", OnFail.Raise, c => { calls.Add("second"); return new GuardrailResult(true); });
+
+        var handler = GuardrailHandlerFactory.Create([first, second]);
+        var result = (Dictionary<string, object?>)(await handler(Args("x"), null))!;
+
+        Assert.Equal(["first"], calls);
+        Assert.False((bool)result["passed"]!);
+        Assert.Equal("first", result["guardrail_name"]);
+        Assert.Equal("raise", result["on_fail"]);
+    }
+
+    [Fact]
+    public async Task Factory_AllPass_ReturnsPassShape()
+    {
+        var g = Custom("g", OnFail.Raise, _ => new GuardrailResult(true));
+        var handler = GuardrailHandlerFactory.Create([g]);
+        var result = (Dictionary<string, object?>)(await handler(Args("x"), null))!;
+
+        Assert.True((bool)result["passed"]!);
+        Assert.Equal("pass", result["on_fail"]);
+        Assert.Equal("", result["guardrail_name"]);
+        Assert.False((bool)result["should_continue"]!);
+    }
+
+    [Fact]
+    public async Task Factory_Retry_EscalatesToRaise_AtMaxRetries()
+    {
+        var g = Custom("g", OnFail.Retry, _ => new GuardrailResult(false, "bad"), maxRetries: 2);
+        var handler = GuardrailHandlerFactory.Create([g]);
+
+        var underLimit = (Dictionary<string, object?>)(await handler(Args("x", iteration: 1), null))!;
+        Assert.Equal("retry", underLimit["on_fail"]);
+        Assert.True((bool)underLimit["should_continue"]!);
+
+        var atLimit = (Dictionary<string, object?>)(await handler(Args("x", iteration: 2), null))!;
+        Assert.Equal("raise", atLimit["on_fail"]);
+        Assert.False((bool)atLimit["should_continue"]!);
+    }
+
+    [Fact]
+    public async Task Factory_MissingIteration_TreatedAsZero()
+    {
+        // maxRetries=0 means even iteration 0 must escalate immediately.
+        var g = Custom("g", OnFail.Retry, _ => new GuardrailResult(false, "bad"), maxRetries: 0);
+        var handler = GuardrailHandlerFactory.Create([g]);
+
+        var result = (Dictionary<string, object?>)(await handler(Args("x"), null))!;
+        Assert.Equal("raise", result["on_fail"]);
+    }
+
+    [Fact]
+    public async Task Factory_Fix_EscalatesToRaise_WhenNoFixedOutput()
+    {
+        var g = Custom("g", OnFail.Fix, _ => new GuardrailResult(false, "bad"));
+        var handler = GuardrailHandlerFactory.Create([g]);
+
+        var result = (Dictionary<string, object?>)(await handler(Args("x"), null))!;
+        Assert.Equal("raise", result["on_fail"]);
+    }
+
+    [Fact]
+    public async Task Factory_Fix_KeepsFix_WhenFixedOutputPresent()
+    {
+        var g = Custom("g", OnFail.Fix, _ => new GuardrailResult(false, "bad", FixedOutput: "cleaned"));
+        var handler = GuardrailHandlerFactory.Create([g]);
+
+        var result = (Dictionary<string, object?>)(await handler(Args("x"), null))!;
+        Assert.Equal("fix", result["on_fail"]);
+        Assert.Equal("cleaned", result["fixed_output"]);
+    }
+
+    [Fact]
+    public async Task Factory_HandlerException_Propagates()
+    {
+        var g = Custom("g", OnFail.Raise, _ => throw new InvalidOperationException("boom"));
+        var handler = GuardrailHandlerFactory.Create([g]);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => handler(Args("x"), null));
+    }
+
+    // ── registration: one combined worker per scope, dedup ────────────────
+
+    private static WorkerManager NewManager() =>
+        new(new Configuration { BasePath = "http://127.0.0.1:1/api" }, pollIntervalMs: 60_000, threadCount: 1);
+
+    private static Conductor.Client.Models.Task NewTask(string content, int? iteration = null)
+    {
+        var input = new Dictionary<string, object> { ["content"] = content };
+        if (iteration is not null) input["iteration"] = iteration.Value;
+        return new() { WorkflowInstanceId = "wf-1", TaskId = "task-1", InputData = input };
+    }
+
+    private sealed class MixedGuardrailHost
+    {
+        [Guardrail("check_one")]
+        public GuardrailResult CheckOne(string content) => new(true);
+
+        [Guardrail("check_two")]
+        public GuardrailResult CheckTwo(string content) => new(true);
+    }
+
+    [Fact]
+    public void OneOfEachType_RegistersExactlyOneWorker_NamedForScope()
+    {
+        var manager = NewManager();
+        var agent = new Agent("support_agent")
+        {
+            Model = "openai/gpt-4o",
+            Guardrails =
+            [
+                .. GuardrailRegistry.FromInstance(new MixedGuardrailHost()),
+                RegexGuardrail.Create("secret", name: "no_secret"),
+                LLMGuardrail.Create("openai/gpt-4o-mini", "no bad stuff", name: "safety"),
+            ],
+        };
+
+        manager.RegisterAgentTools(agent);
+
+        Assert.NotNull(manager.WorkerForTesting("support_agent_output_guardrail"));
+        // Regex/llm have no Handler — they register nothing (server-evaluated).
+        Assert.Null(manager.WorkerForTesting("no_secret"));
+        Assert.Null(manager.WorkerForTesting("safety"));
+    }
+
+    [Fact]
+    public void ToolScope_RegistersWorker_NamedForTool()
+    {
+        var manager = NewManager();
+        var tool = new ToolDef
+        {
+            Name = "run_query",
+            Description = "run a query",
+            Guardrails = [.. GuardrailRegistry.FromInstance(new MixedGuardrailHost())],
+        };
+        var agent = new Agent("support_agent") { Model = "openai/gpt-4o", Tools = [tool] };
+
+        manager.RegisterAgentTools(agent);
+
+        Assert.NotNull(manager.WorkerForTesting("run_query_output_guardrail"));
+    }
+
+    [Fact]
+    public async Task CombinedWorker_EvaluatesBothGuardrails_FirstFailureWins()
+    {
+        var manager = NewManager();
+        var agent = new Agent("support_agent")
+        {
+            Model = "openai/gpt-4o",
+            Guardrails = [.. GuardrailRegistry.FromInstance(new MixedGuardrailHost())],
+        };
+        manager.RegisterAgentTools(agent);
+
+        var worker = manager.WorkerForTesting("support_agent_output_guardrail");
+        Assert.NotNull(worker);
+
+        var result = await worker!.Execute(NewTask("hello"), CancellationToken.None);
+        Assert.True((bool)result.OutputData["passed"]!);
+    }
+
+    [Fact]
+    public void DuplicateRegistration_SameScope_RegistersOnlyOneWorker()
+    {
+        var manager = NewManager();
+        var agent = new Agent("support_agent")
+        {
+            Model = "openai/gpt-4o",
+            Guardrails = [.. GuardrailRegistry.FromInstance(new MixedGuardrailHost())],
+        };
+
+        manager.RegisterAgentTools(agent);
+        manager.RegisterAgentTools(agent); // re-registered, e.g. overlapping runs
+
+        Assert.Equal(1, manager.WorkerCountForTesting("support_agent_output_guardrail"));
+    }
+
+    [Fact]
+    public void AgentAndTool_SharingScopeName_RegisterOnlyOneWorker()
+    {
+        // An agent-level guardrail and a tool named the same as the agent both
+        // want "x_output_guardrail" — without dedup this would double-poll one
+        // Conductor task queue with two competing handlers.
+        var manager = NewManager();
+        var tool = new ToolDef
+        {
+            Name = "x",
+            Description = "d",
+            Guardrails = [.. GuardrailRegistry.FromInstance(new MixedGuardrailHost())],
+        };
+        var agent = new Agent("x")
+        {
+            Model = "openai/gpt-4o",
+            Tools = [tool],
+            Guardrails = [.. GuardrailRegistry.FromInstance(new MixedGuardrailHost())],
+        };
+
+        manager.RegisterAgentTools(agent);
+
+        Assert.Equal(1, manager.WorkerCountForTesting("x_output_guardrail"));
+    }
+}

--- a/Conductor.AI/AgentConfigSerializer.cs
+++ b/Conductor.AI/AgentConfigSerializer.cs
@@ -259,7 +259,7 @@ internal static class AgentConfigSerializer
         if (agent.Guardrails.Count > 0)
         {
             var guardrails = new JsonArray();
-            foreach (var g in agent.Guardrails) guardrails.Add(SerializeGuardrail(g));
+            foreach (var g in agent.Guardrails) guardrails.Add(SerializeGuardrail(g, agent.Name));
             cfg["guardrails"] = guardrails;
         }
 
@@ -518,7 +518,7 @@ internal static class AgentConfigSerializer
         if (tool.Guardrails.Count > 0)
         {
             var gArr = new JsonArray();
-            foreach (var g in tool.Guardrails) gArr.Add(SerializeGuardrail(g));
+            foreach (var g in tool.Guardrails) gArr.Add(SerializeGuardrail(g, tool.Name));
             t["guardrails"] = gArr;
         }
 
@@ -636,22 +636,49 @@ internal static class AgentConfigSerializer
         return hMap;
     }
 
-    internal static JsonObject SerializeGuardrail(GuardrailDef g) => new()
+    /// <summary>
+    /// Regex/llm: real <c>guardrailType</c> + data, server-evaluated, no worker.
+    /// Custom (local <see cref="GuardrailDef.Handler"/>): <c>taskName = {scopeName}_output_guardrail</c>,
+    /// the combined per-scope worker. External: remote worker by name, no taskName.
+    /// </summary>
+    internal static JsonObject SerializeGuardrail(GuardrailDef g, string scopeName)
     {
-        ["name"] = g.Name,
-        ["position"] = g.Position == Position.Input ? "input" : "output",
-        ["onFail"] = g.OnFail switch
+        GuardrailDef.Validate(g);
+
+        var map = new JsonObject
         {
-            OnFail.Retry => "retry",
-            OnFail.Fix => "fix",
-            OnFail.Human => "human",
-            _ => "raise",
-        },
-        ["maxRetries"] = g.MaxRetries,
-        // External guardrails reference a remote worker by name. Regex/LLM/custom
-        // guardrails run as locally-registered worker tasks, so they serialize as
-        // "custom" (the server treats them identically — a named task).
-        ["guardrailType"] = g.External ? "external" : "custom",
-        ["taskName"] = g.Name,  // Conductor task name = guardrail name
-    };
+            ["name"] = g.Name,
+            ["position"] = g.Position == Position.Input ? "input" : "output",
+            ["onFail"] = g.OnFail switch
+            {
+                OnFail.Retry => "retry",
+                OnFail.Fix => "fix",
+                OnFail.Human => "human",
+                _ => "raise",
+            },
+            ["maxRetries"] = g.MaxRetries,
+            ["guardrailType"] = g.GuardrailType,
+        };
+
+        if (g.Handler is not null)
+            map["taskName"] = $"{scopeName}_output_guardrail";
+
+        if (g.Patterns is { Count: > 0 })
+        {
+            var patterns = new JsonArray();
+            foreach (var p in g.Patterns) patterns.Add(p);
+            map["patterns"] = patterns;
+            map["mode"] = g.Mode ?? "block";
+            if (g.Message is not null) map["message"] = g.Message;
+        }
+
+        if (g.Model is not null)
+        {
+            map["model"] = g.Model;
+            map["policy"] = g.Policy;
+            if (g.MaxTokens is not null) map["maxTokens"] = g.MaxTokens.Value;
+        }
+
+        return map;
+    }
 }

--- a/Conductor.AI/AgentRuntime.cs
+++ b/Conductor.AI/AgentRuntime.cs
@@ -383,8 +383,12 @@ public sealed class AgentRuntime : IAsyncDisposable, IDisposable
             IsComplete = node["isComplete"]?.GetValue<bool>() ?? false,
             IsRunning = node["isRunning"]?.GetValue<bool>() ?? false,
             IsWaiting = node["isWaiting"]?.GetValue<bool>() ?? false,
+            Output = node["output"] is JsonObject outObj
+                ? System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(
+                    outObj.ToJsonString(), AgentspanJson.Options)
+                : null,
             StatusValue = node["status"]?.GetValue<string>(),
-            Reason = node["reason"]?.GetValue<string>(),
+            Reason = node["reasonForIncompletion"]?.GetValue<string>(),
             CurrentTask = node["currentTask"]?.GetValue<string>(),
             PendingTool = node["pendingTool"] is not null
                 ? System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(

--- a/Conductor.AI/AgentRuntime.cs
+++ b/Conductor.AI/AgentRuntime.cs
@@ -500,6 +500,10 @@ public sealed class AgentRuntime : IAsyncDisposable, IDisposable
     /// <summary>Test-only seam — observe whether a worker manager is currently active.</summary>
     internal bool HasActiveWorkers => _workers is not null;
 
+    /// <summary>Test-only seam — look up a registered worker by task name (e.g. to assert a
+    /// server-evaluated guardrail registered no local worker at all).</summary>
+    internal AgentToolWorker? WorkerForTesting(string taskName) => _workers?.WorkerForTesting(taskName);
+
     // ── Disposal ─────────────────────────────────────────────
 
     public async ValueTask DisposeAsync()

--- a/Conductor.AI/AgentRuntime.cs
+++ b/Conductor.AI/AgentRuntime.cs
@@ -377,6 +377,7 @@ public sealed class AgentRuntime : IAsyncDisposable, IDisposable
     {
         var node = await _http.GetStatusAsync(executionId, ct);
         if (node is null) return new AgentStatus { ExecutionId = executionId };
+        var statusValue = node["status"]?.GetValue<string>();
         return new AgentStatus
         {
             ExecutionId = node["executionId"]?.GetValue<string>() ?? executionId,
@@ -387,8 +388,8 @@ public sealed class AgentRuntime : IAsyncDisposable, IDisposable
                 ? System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(
                     outObj.ToJsonString(), AgentspanJson.Options)
                 : null,
-            StatusValue = node["status"]?.GetValue<string>(),
-            Reason = node["reasonForIncompletion"]?.GetValue<string>(),
+            StatusValue = statusValue,
+            Reason = statusValue != "COMPLETED" ? node["reasonForIncompletion"]?.GetValue<string>() : null,
             CurrentTask = node["currentTask"]?.GetValue<string>(),
             PendingTool = node["pendingTool"] is not null
                 ? System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(

--- a/Conductor.AI/Guardrail.cs
+++ b/Conductor.AI/Guardrail.cs
@@ -57,18 +57,55 @@ public sealed class GuardrailDef
     // Handler receives the content string and returns a GuardrailResult.
     internal Func<string, Task<GuardrailResult>>? Handler { get; init; }
 
+    // ── Server-evaluated guardrail data (guardrailType "regex") ──
+    public IReadOnlyList<string>? Patterns { get; init; }
+    public string? Mode { get; init; }
+    public string? Message { get; init; }
+
+    // ── Server-evaluated guardrail data (guardrailType "llm") ──
+    public string? Model { get; init; }
+    public string? Policy { get; init; }
+    public int? MaxTokens { get; init; }
+
     /// <summary>
-    /// Validate the position/on_fail combination, mirroring Python's
-    /// <c>Guardrail.__init__</c>: <c>on_fail=human</c> is only valid for
-    /// <c>position=output</c> (input guardrails are client-side and cannot
-    /// pause a workflow).
+    /// Non-blank name, non-negative maxRetries, <c>on_fail=human</c> only for output
+    /// position (input runs client-side, can't pause a workflow), type-specific data
+    /// for regex/llm/custom. Mirrors Java's <c>GuardrailDef.Builder.build()</c>.
     /// </summary>
-    internal static void ValidatePositionOnFail(Position position, OnFail onFail)
+    internal static void Validate(GuardrailDef def)
     {
-        if (onFail == OnFail.Human && position == Position.Input)
+        if (string.IsNullOrWhiteSpace(def.Name))
+            throw new ArgumentException("GuardrailDef requires a non-blank name.");
+        if (def.MaxRetries < 0)
+            throw new ArgumentException($"GuardrailDef '{def.Name}': maxRetries must be non-negative.");
+        if (def.OnFail == OnFail.Human && def.Position == Position.Input)
             throw new ArgumentException(
                 "on_fail='human' is only valid for position='output' " +
                 "(input guardrails are client-side and cannot pause a workflow)");
+
+        switch (def.GuardrailType)
+        {
+            case "regex":
+                if (def.Patterns is null || def.Patterns.Count == 0)
+                    throw new ArgumentException(
+                        $"GuardrailDef '{def.Name}': regex guardrails require at least one pattern.");
+                if (def.Mode != "block" && def.Mode != "allow")
+                    throw new ArgumentException(
+                        $"GuardrailDef '{def.Name}': mode must be 'block' or 'allow', got '{def.Mode}'.");
+                break;
+            case "llm":
+                if (string.IsNullOrWhiteSpace(def.Model))
+                    throw new ArgumentException($"GuardrailDef '{def.Name}': llm guardrails require a model.");
+                if (string.IsNullOrWhiteSpace(def.Policy))
+                    throw new ArgumentException($"GuardrailDef '{def.Name}': llm guardrails require a policy.");
+                break;
+            case "custom":
+                if (def.Handler is null)
+                    throw new ArgumentException(
+                        $"GuardrailDef '{def.Name}': custom guardrails require a handler. " +
+                        "Use Guardrail.External(...) for a guardrail backed by a remote worker.");
+                break;
+        }
     }
 }
 
@@ -95,8 +132,7 @@ public static class Guardrail
         OnFail onFail = OnFail.Raise,
         int maxRetries = 3)
     {
-        GuardrailDef.ValidatePositionOnFail(position, onFail);
-        return new GuardrailDef
+        var def = new GuardrailDef
         {
             Name = name,
             Position = position,
@@ -105,6 +141,8 @@ public static class Guardrail
             GuardrailType = "external",
             Handler = null,
         };
+        GuardrailDef.Validate(def);
+        return def;
     }
 }
 
@@ -124,14 +162,16 @@ public static class GuardrailRegistry
             if (attr is null) continue;
 
             var name = attr.Name ?? ToolRegistry.ToSnakeCase(method.Name);
-            defs.Add(new GuardrailDef
+            var def = new GuardrailDef
             {
                 Name = name,
                 Position = attr.Position,
                 OnFail = attr.OnFail,
                 MaxRetries = attr.MaxRetries,
                 Handler = BuildHandler(instance, method),
-            });
+            };
+            GuardrailDef.Validate(def);
+            defs.Add(def);
         }
         return defs;
     }
@@ -170,20 +210,20 @@ public static class RegexGuardrail
         OnFail onFail = OnFail.Raise,
         int maxRetries = 3)
     {
-        if (mode != "block" && mode != "allow")
-            throw new ArgumentException($"Invalid mode '{mode}'. Must be 'block' or 'allow'.", nameof(mode));
-        GuardrailDef.ValidatePositionOnFail(position, onFail);
-
-        var compiled = patterns.Select(p => new Regex(p, RegexOptions.Compiled)).ToList();
+        var patternList = patterns.ToList();
+        var compiled = patternList.Select(p => new Regex(p, RegexOptions.Compiled)).ToList();
         var guardrailName = name ?? "regex_guardrail";
 
-        return new GuardrailDef
+        var def = new GuardrailDef
         {
             Name = guardrailName,
             Position = position,
             OnFail = onFail,
             MaxRetries = maxRetries,
             GuardrailType = "regex",
+            Patterns = patternList,
+            Mode = mode,
+            Message = message,
             Handler = content =>
             {
                 bool matched = compiled.Any(rx => rx.IsMatch(content));
@@ -201,6 +241,8 @@ public static class RegexGuardrail
                 return Task.FromResult(new GuardrailResult(true));
             },
         };
+        GuardrailDef.Validate(def);
+        return def;
     }
 
     /// <summary>Convenience overload accepting a single pattern string.</summary>
@@ -238,16 +280,18 @@ public static class LLMGuardrail
         int maxRetries = 3,
         string? apiKey = null)
     {
-        GuardrailDef.ValidatePositionOnFail(position, onFail);
         var guardrailName = name ?? "llm_guardrail";
 
-        return new GuardrailDef
+        var def = new GuardrailDef
         {
             Name = guardrailName,
             Position = position,
             OnFail = onFail,
             MaxRetries = maxRetries,
             GuardrailType = "llm",
+            Model = model,
+            Policy = policy,
+            MaxTokens = maxTokens,
             Handler = async content =>
             {
                 try
@@ -307,5 +351,7 @@ public static class LLMGuardrail
                 }
             },
         };
+        GuardrailDef.Validate(def);
+        return def;
     }
 }

--- a/Conductor.AI/Guardrail.cs
+++ b/Conductor.AI/Guardrail.cs
@@ -11,9 +11,6 @@
  * specific language governing permissions and limitations under the License.
  */
 using System.Reflection;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 
 namespace Conductor.AI;
 
@@ -198,6 +195,9 @@ public static class GuardrailRegistry
 /// A guardrail that validates content against regex patterns.
 /// Block mode (default): fails if any pattern matches.
 /// Allow mode: fails if NO pattern matches.
+///
+/// <para>Serialized as <c>guardrailType: "regex"</c> — the Conductor server evaluates the
+/// patterns (ECMAScript/GraalJS dialect). No worker process is needed.</para>
 /// </summary>
 public static class RegexGuardrail
 {
@@ -210,36 +210,16 @@ public static class RegexGuardrail
         OnFail onFail = OnFail.Raise,
         int maxRetries = 3)
     {
-        var patternList = patterns.ToList();
-        var compiled = patternList.Select(p => new Regex(p, RegexOptions.Compiled)).ToList();
-        var guardrailName = name ?? "regex_guardrail";
-
         var def = new GuardrailDef
         {
-            Name = guardrailName,
+            Name = name ?? "regex_guardrail",
             Position = position,
             OnFail = onFail,
             MaxRetries = maxRetries,
             GuardrailType = "regex",
-            Patterns = patternList,
+            Patterns = patterns.ToList(),
             Mode = mode,
             Message = message,
-            Handler = content =>
-            {
-                bool matched = compiled.Any(rx => rx.IsMatch(content));
-
-                if (mode == "block" && matched)
-                {
-                    var msg = message ?? "Content matched a blocked pattern.";
-                    return Task.FromResult(new GuardrailResult(false, msg));
-                }
-                if (mode == "allow" && !matched)
-                {
-                    var msg = message ?? "Content did not match any allowed pattern.";
-                    return Task.FromResult(new GuardrailResult(false, msg));
-                }
-                return Task.FromResult(new GuardrailResult(true));
-            },
         };
         GuardrailDef.Validate(def);
         return def;
@@ -264,12 +244,12 @@ public static class RegexGuardrail
 /// The model receives the policy + content and must respond with JSON:
 ///   {"passed": true/false, "reason": "..."}
 ///
-/// Requires OPENAI_API_KEY in the environment (or set the apiKey parameter).
+/// <para>Serialized as <c>guardrailType: "llm"</c> — the Conductor server calls the
+/// specified model via its own configured LLM providers. No worker process, HTTP client,
+/// or API key is needed on the client side.</para>
 /// </summary>
 public static class LLMGuardrail
 {
-    private static readonly System.Net.Http.HttpClient _http = new();
-
     public static GuardrailDef Create(
         string model,
         string policy,
@@ -277,14 +257,11 @@ public static class LLMGuardrail
         int? maxTokens = null,
         Position position = Position.Output,
         OnFail onFail = OnFail.Raise,
-        int maxRetries = 3,
-        string? apiKey = null)
+        int maxRetries = 3)
     {
-        var guardrailName = name ?? "llm_guardrail";
-
         var def = new GuardrailDef
         {
-            Name = guardrailName,
+            Name = name ?? "llm_guardrail",
             Position = position,
             OnFail = onFail,
             MaxRetries = maxRetries,
@@ -292,64 +269,6 @@ public static class LLMGuardrail
             Model = model,
             Policy = policy,
             MaxTokens = maxTokens,
-            Handler = async content =>
-            {
-                try
-                {
-                    var key = apiKey ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY") ?? "";
-                    var prompt =
-                        "You are a content safety evaluator. Evaluate the following content against this policy:\n\n" +
-                        $"POLICY: {policy}\n\n" +
-                        $"CONTENT: {content}\n\n" +
-                        "Respond with ONLY a JSON object: {\"passed\": true/false, \"reason\": \"...\"}";
-
-                    // Parse provider/model format
-                    var modelName = model.Contains('/') ? model.Split('/', 2)[1] : model;
-                    var provider = model.Contains('/') ? model.Split('/', 2)[0] : "openai";
-
-                    string apiUrl = provider switch
-                    {
-                        "anthropic" => "https://api.anthropic.com/v1/messages",
-                        _ => "https://api.openai.com/v1/chat/completions",
-                    };
-
-                    var requestBody = new
-                    {
-                        model = modelName,
-                        messages = new[] { new { role = "user", content = prompt } },
-                        max_tokens = maxTokens ?? 300,
-                        temperature = 0,
-                    };
-
-                    var json = System.Text.Json.JsonSerializer.Serialize(requestBody);
-                    using var req = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, apiUrl);
-                    req.Headers.Add("Authorization", $"Bearer {key}");
-                    req.Content = new System.Net.Http.StringContent(json, System.Text.Encoding.UTF8, "application/json");
-
-                    using var resp = await _http.SendAsync(req);
-                    var body = await resp.Content.ReadAsStringAsync();
-                    var node = System.Text.Json.Nodes.JsonNode.Parse(body);
-                    var text = node?["choices"]?[0]?["message"]?["content"]?.GetValue<string>() ?? "";
-
-                    // Parse JSON response from LLM
-                    try
-                    {
-                        var resultNode = System.Text.Json.Nodes.JsonNode.Parse(text);
-                        var passed = resultNode?["passed"]?.GetValue<bool>() ?? false;
-                        var reason = resultNode?["reason"]?.GetValue<string>() ?? "";
-                        return new GuardrailResult(passed, reason);
-                    }
-                    catch
-                    {
-                        // If LLM didn't return valid JSON, be conservative and fail
-                        return new GuardrailResult(false, $"LLM guardrail returned unparseable response: {text[..Math.Min(200, text.Length)]}");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    return new GuardrailResult(false, $"LLM guardrail evaluation error: {ex.Message}");
-                }
-            },
         };
         GuardrailDef.Validate(def);
         return def;

--- a/Conductor.AI/GuardrailHandlerFactory.cs
+++ b/Conductor.AI/GuardrailHandlerFactory.cs
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+using System.Text.Json;
+
+namespace Conductor.AI;
+
+/// <summary>
+/// Combined handler for a scope's local (custom) guardrails — one worker per agent/tool,
+/// evaluates in declaration order, first failure wins. Mirrors Java's
+/// <c>GuardrailHandlerFactory</c>.
+/// </summary>
+internal static class GuardrailHandlerFactory
+{
+    /// <summary>
+    /// Handler exceptions propagate to the worker runner (failed task), matching Java —
+    /// not converted into a guardrail result.
+    /// </summary>
+    public static Func<Dictionary<string, JsonElement>, ToolContext?, Task<object?>> Create(
+        IReadOnlyList<GuardrailDef> guardrails)
+    {
+        var local = guardrails.ToList();
+        return async (args, _ctx) =>
+        {
+            string content = args.TryGetValue("content", out var contentEl)
+                ? (contentEl.ValueKind == JsonValueKind.String
+                    ? contentEl.GetString() ?? ""
+                    : contentEl.GetRawText())
+                : "";
+
+            int iteration = args.TryGetValue("iteration", out var iterEl) &&
+                            iterEl.ValueKind == JsonValueKind.Number
+                ? iterEl.GetInt32()
+                : 0;
+
+            foreach (var guardrail in local)
+            {
+                var result = await guardrail.Handler!(content);
+
+                if (!result.Passed)
+                {
+                    var effectiveOnFail = guardrail.OnFail;
+                    if (effectiveOnFail == OnFail.Retry && iteration >= guardrail.MaxRetries)
+                        effectiveOnFail = OnFail.Raise;
+                    if (effectiveOnFail == OnFail.Fix && result.FixedOutput is null)
+                        effectiveOnFail = OnFail.Raise;
+
+                    return (object)new Dictionary<string, object?>
+                    {
+                        ["passed"] = false,
+                        ["message"] = result.Message ?? "",
+                        ["on_fail"] = effectiveOnFail.ToString().ToLowerInvariant(),
+                        ["fixed_output"] = result.FixedOutput,
+                        ["guardrail_name"] = guardrail.Name,
+                        ["should_continue"] = effectiveOnFail == OnFail.Retry,
+                    };
+                }
+            }
+
+            return (object)new Dictionary<string, object?>
+            {
+                ["passed"] = true,
+                ["message"] = "",
+                ["on_fail"] = "pass",
+                ["fixed_output"] = null,
+                ["guardrail_name"] = "",
+                ["should_continue"] = false,
+            };
+        };
+    }
+}

--- a/Conductor.AI/IAgentClient.cs
+++ b/Conductor.AI/IAgentClient.cs
@@ -81,6 +81,9 @@ public interface IAgentClient : IDisposable, IAsyncDisposable
     /// <summary>Fetch the workflow definition (without tasks) — e.g. to read taskToDomain. Null on any failure (enrichment read).</summary>
     Task<JsonNode?> GetWorkflowAsync(string executionId, CancellationToken ct = default);
 
+    /// <summary>Fetch the workflow with its tasks — used to aggregate tool calls from call_* tasks. Null on any failure (enrichment read).</summary>
+    Task<JsonNode?> GetWorkflowWithTasksAsync(string executionId, CancellationToken ct = default);
+
     // ── Conveniences (agent-level, control-plane) ──────────────
 
     /// <summary>Compile + register + start an agent, then poll to a result. No local tool workers.</summary>

--- a/Conductor.AI/OrkesAgentClient.cs
+++ b/Conductor.AI/OrkesAgentClient.cs
@@ -210,6 +210,13 @@ public sealed class OrkesAgentClient : IAgentClient
             queryParams: new List<KeyValuePair<string, string>> { new("includeTasks", "false") },
             nullOnFailure: true);
 
+    /// <summary>Fetch the workflow with its tasks — used to aggregate tool calls from call_* tasks. Enrichment read — null on any failure.</summary>
+    public async Task<JsonNode?> GetWorkflowWithTasksAsync(string executionId, CancellationToken ct = default)
+        => await ExecuteJsonAsync(
+            Method.Get, $"/workflow/{Uri.EscapeDataString(executionId)}", null, ct,
+            queryParams: new List<KeyValuePair<string, string>> { new("includeTasks", "true") },
+            nullOnFailure: true);
+
     // ── Run by name ──────────────────────────────────────────
 
     /// <summary>Start a pre-deployed workflow by name (no agentConfig payload).</summary>

--- a/Conductor.AI/Result.cs
+++ b/Conductor.AI/Result.cs
@@ -305,7 +305,10 @@ public sealed class AgentHandle
                 {
                     // Fetch full execution record for token usage and finish reason
                     var execution = await _http.GetExecutionAsync(_executionId, cancellationToken);
-                    return BuildResult(status!, s, execution);
+                    // Java parity: walk the workflow's tasks once to aggregate tool calls
+                    // from call_* tasks (enrichment read — null is fine, yields no tool calls).
+                    var workflowWithTasks = await _http.GetWorkflowWithTasksAsync(_executionId, cancellationToken);
+                    return BuildResult(status!, s, execution, workflowWithTasks);
                 }
                 await Task.Delay(500, cancellationToken);
             }
@@ -360,6 +363,7 @@ public sealed class AgentHandle
         var node = await _http.GetStatusAsync(_executionId, cancellationToken);
         if (node is null) return new AgentStatus { ExecutionId = _executionId };
 
+        var statusValue = node["status"]?.GetValue<string>();
         return new AgentStatus
         {
             ExecutionId = node["executionId"]?.GetValue<string>() ?? _executionId,
@@ -369,8 +373,8 @@ public sealed class AgentHandle
             Output = node["output"] is JsonObject outObj
                 ? JsonSerializer.Deserialize<Dictionary<string, object>>(outObj.ToJsonString(), AgentspanJson.Options)
                 : null,
-            StatusValue = node["status"]?.GetValue<string>(),
-            Reason = node["reasonForIncompletion"]?.GetValue<string>(),
+            StatusValue = statusValue,
+            Reason = statusValue != "COMPLETED" ? node["reasonForIncompletion"]?.GetValue<string>() : null,
             CurrentTask = node["currentTask"]?.GetValue<string>(),
         };
     }
@@ -483,7 +487,8 @@ public sealed class AgentHandle
     /// <summary>Send a signal message to this execution (synchronous).</summary>
     public void Signal(object message) => SignalAsync(message).GetAwaiter().GetResult();
 
-    private static AgentResult BuildResult(JsonNode status, string statusStr, JsonNode? execution = null)
+    private static AgentResult BuildResult(
+        JsonNode status, string statusStr, JsonNode? execution = null, JsonNode? workflowWithTasks = null)
     {
         var output = status["output"];
         var parsedStatus = statusStr switch
@@ -536,9 +541,50 @@ public sealed class AgentHandle
             ExecutionId = status["executionId"]?.GetValue<string>() ?? "",
             Status = parsedStatus,
             Output = outputDict,
-            Error = status["reasonForIncompletion"]?.GetValue<string>(),
+            Error = parsedStatus != Status.Completed ? status["reasonForIncompletion"]?.GetValue<string>() : null,
+            ToolCalls = ExtractToolCalls(workflowWithTasks),
             TokenUsage = tokenUsage,
             FinishReason = finishReason,
         };
+    }
+
+    /// <summary>
+    /// Java parity (<c>AgentHandle.extractFromTasks</c>): walk the workflow's tasks
+    /// and collect one entry per LLM-dispatched tool call — tasks whose
+    /// <c>referenceTaskName</c> starts with <c>call_</c> — capturing the tool name,
+    /// its input args (internal runtime fields stripped), and its result.
+    /// </summary>
+    private static List<Dictionary<string, object>>? ExtractToolCalls(JsonNode? workflowWithTasks)
+    {
+        if (workflowWithTasks?["tasks"] is not JsonArray tasks) return null;
+
+        List<Dictionary<string, object>>? toolCalls = null;
+        foreach (var task in tasks)
+        {
+            var refName = task?["referenceTaskName"]?.GetValue<string>();
+            var outputData = task?["outputData"] as JsonObject;
+            if (refName is null || !refName.StartsWith("call_", StringComparison.Ordinal) || outputData is null)
+                continue;
+
+            var tc = new Dictionary<string, object> { ["name"] = task!["taskType"]?.GetValue<string>() ?? "" };
+            if (task["inputData"] is JsonObject inputData)
+            {
+                var cleaned = new Dictionary<string, object>();
+                foreach (var kv in inputData)
+                {
+                    var k = kv.Key;
+                    if (k.StartsWith('_') || k is "method" or "evaluatorType" or "expression" or "ctx"
+                        or "workerTag" or "agentConfig")
+                        continue;
+                    cleaned[k] = JsonSerializer.Deserialize<object>(kv.Value?.ToJsonString() ?? "null", AgentspanJson.Options)!;
+                }
+                tc["args"] = cleaned;
+            }
+            if (outputData.TryGetPropertyValue("result", out var resultNode) && resultNode is not null)
+                tc["result"] = JsonSerializer.Deserialize<object>(resultNode.ToJsonString(), AgentspanJson.Options)!;
+
+            (toolCalls ??= new List<Dictionary<string, object>>()).Add(tc);
+        }
+        return toolCalls;
     }
 }

--- a/Conductor.AI/Result.cs
+++ b/Conductor.AI/Result.cs
@@ -366,8 +366,11 @@ public sealed class AgentHandle
             IsComplete = node["isComplete"]?.GetValue<bool>() ?? false,
             IsRunning = node["isRunning"]?.GetValue<bool>() ?? false,
             IsWaiting = node["isWaiting"]?.GetValue<bool>() ?? false,
+            Output = node["output"] is JsonObject outObj
+                ? JsonSerializer.Deserialize<Dictionary<string, object>>(outObj.ToJsonString(), AgentspanJson.Options)
+                : null,
             StatusValue = node["status"]?.GetValue<string>(),
-            Reason = node["reason"]?.GetValue<string>(),
+            Reason = node["reasonForIncompletion"]?.GetValue<string>(),
             CurrentTask = node["currentTask"]?.GetValue<string>(),
         };
     }
@@ -533,7 +536,7 @@ public sealed class AgentHandle
             ExecutionId = status["executionId"]?.GetValue<string>() ?? "",
             Status = parsedStatus,
             Output = outputDict,
-            Error = status["error"]?.GetValue<string>(),
+            Error = status["reasonForIncompletion"]?.GetValue<string>(),
             TokenUsage = tokenUsage,
             FinishReason = finishReason,
         };

--- a/Conductor.AI/WorkerManager.cs
+++ b/Conductor.AI/WorkerManager.cs
@@ -53,6 +53,24 @@ internal sealed class WorkerManager : IAsyncDisposable
     /// <summary>Test-only seam — look up a registered worker by task name to exercise its handler directly.</summary>
     internal AgentToolWorker? WorkerForTesting(string taskName) => _workers.FirstOrDefault(w => w.TaskType == taskName);
 
+    /// <summary>Test-only seam — count registered workers for a task name, to assert dedup.</summary>
+    internal int WorkerCountForTesting(string taskName) => _workers.Count(w => w.TaskType == taskName);
+
+    /// <summary>
+    /// Skip if a worker already exists for (TaskType, Domain) — first-wins. A duplicate
+    /// (same agent/tool/guardrail registered twice) would double-poll one task queue.
+    /// </summary>
+    private void AddWorker(AgentToolWorker worker)
+    {
+        if (_workers.Any(w => w.TaskType == worker.TaskType && w.WorkerSettings.Domain == worker.WorkerSettings.Domain))
+        {
+            System.Diagnostics.Trace.TraceInformation(
+                $"Worker for task '{worker.TaskType}' (domain '{worker.WorkerSettings.Domain}') already registered — skipping duplicate.");
+            return;
+        }
+        _workers.Add(worker);
+    }
+
     private AgentToolWorker NewWorker(
         string taskName,
         Func<Dictionary<string, JsonElement>, ToolContext?, System.Threading.Tasks.Task<object?>> handler,
@@ -94,86 +112,24 @@ internal sealed class WorkerManager : IAsyncDisposable
         foreach (var tool in tools)
         {
             if (tool.Handler is null) continue;
-            _workers.Add(NewWorker(tool.Name, tool.Handler,
+            AddWorker(NewWorker(tool.Name, tool.Handler,
                 credentialNames: tool.Credentials.Length > 0 ? tool.Credentials : null,
                 domain: domain));
         }
     }
 
-    public void RegisterGuardrails(IEnumerable<GuardrailDef> guardrails, string? domain = null)
+    /// <summary>
+    /// One combined worker per scope — <c>{scopeName}_output_guardrail</c>, the taskName
+    /// the serializer stamps on custom guardrails. Regex/llm/external have no
+    /// <see cref="GuardrailDef.Handler"/> and register nothing — server-evaluated.
+    /// </summary>
+    public void RegisterGuardrailWorker(string scopeName, IEnumerable<GuardrailDef> guardrails, string? domain = null)
     {
-        foreach (var g in guardrails)
-        {
-            if (g.Handler is null) continue;
-            var handler = g.Handler;
-            var onFail = g.OnFail;
-            var maxRetries = g.MaxRetries;
-            var gName = g.Name;
+        var local = guardrails.Where(g => g.Handler is not null).ToList();
+        if (local.Count == 0) return;
 
-            _workers.Add(NewWorker(g.Name, async (args, _ctx) =>
-            {
-                string content = args.TryGetValue("content", out var contentEl)
-                    ? (contentEl.ValueKind == JsonValueKind.String
-                        ? contentEl.GetString() ?? ""
-                        : contentEl.GetRawText())
-                    : "";
-
-                int iteration = args.TryGetValue("iteration", out var iterEl) &&
-                                iterEl.ValueKind == JsonValueKind.Number
-                    ? iterEl.GetInt32()
-                    : 0;
-
-                GuardrailResult result;
-                try
-                {
-                    result = await handler(content);
-                }
-                catch (Exception ex)
-                {
-                    var effectiveOnFailOnEx = onFail;
-                    if (effectiveOnFailOnEx == OnFail.Retry && iteration >= maxRetries)
-                        effectiveOnFailOnEx = OnFail.Raise;
-                    return (object)new Dictionary<string, object?>
-                    {
-                        ["passed"] = false,
-                        ["message"] = $"Guardrail error: {ex.Message}",
-                        ["on_fail"] = effectiveOnFailOnEx.ToString().ToLowerInvariant(),
-                        ["fixed_output"] = null,
-                        ["guardrail_name"] = gName,
-                        ["should_continue"] = effectiveOnFailOnEx == OnFail.Retry,
-                    };
-                }
-
-                if (!result.Passed)
-                {
-                    var effectiveOnFail = onFail;
-                    if (effectiveOnFail == OnFail.Retry && iteration >= maxRetries)
-                        effectiveOnFail = OnFail.Raise;
-                    if (effectiveOnFail == OnFail.Fix && result.FixedOutput is null)
-                        effectiveOnFail = OnFail.Raise;
-
-                    return (object)new Dictionary<string, object?>
-                    {
-                        ["passed"] = false,
-                        ["message"] = result.Message ?? "",
-                        ["on_fail"] = effectiveOnFail.ToString().ToLowerInvariant(),
-                        ["fixed_output"] = result.FixedOutput,
-                        ["guardrail_name"] = gName,
-                        ["should_continue"] = effectiveOnFail == OnFail.Retry,
-                    };
-                }
-
-                return (object)new Dictionary<string, object?>
-                {
-                    ["passed"] = true,
-                    ["message"] = "",
-                    ["on_fail"] = "pass",
-                    ["fixed_output"] = null,
-                    ["guardrail_name"] = "",
-                    ["should_continue"] = false,
-                };
-            }, domain: domain));
-        }
+        AddWorker(NewWorker(
+            $"{scopeName}_output_guardrail", GuardrailHandlerFactory.Create(local), domain: domain));
     }
 
     public void RegisterAgentTools(Agent agent, string? domain = null)
@@ -182,9 +138,9 @@ internal sealed class WorkerManager : IAsyncDisposable
             RegisterSkillWorkers(agent, domain);
 
         RegisterTools(agent.Tools, domain);
-        RegisterGuardrails(agent.Guardrails, domain);
+        RegisterGuardrailWorker(agent.Name, agent.Guardrails, domain);
         foreach (var tool in agent.Tools)
-            RegisterGuardrails(tool.Guardrails, domain);
+            RegisterGuardrailWorker(tool.Name, tool.Guardrails, domain);
         RegisterCallbacks(agent, domain);
 
         // Local code execution worker — the server adds an execute_code tool to
@@ -217,7 +173,7 @@ internal sealed class WorkerManager : IAsyncDisposable
     {
         foreach (var worker in Skill.CreateSkillWorkers(agent))
         {
-            _workers.Add(NewWorker(worker.Name, async (args, _ctx) =>
+            AddWorker(NewWorker(worker.Name, async (args, _ctx) =>
             {
                 var input = args.ToDictionary(
                     kv => kv.Key,
@@ -246,7 +202,7 @@ internal sealed class WorkerManager : IAsyncDisposable
         var taskName = $"{agent.Name}_execute_code";
         var timeout = agent.CodeExecution?.Timeout ?? 30;
 
-        _workers.Add(NewWorker(taskName, async (args, _) =>
+        AddWorker(NewWorker(taskName, async (args, _) =>
         {
             string language = "python";
             if (args.TryGetValue("language", out var lang) && lang.ValueKind == JsonValueKind.String)
@@ -296,7 +252,7 @@ internal sealed class WorkerManager : IAsyncDisposable
         {
             var cb = agent.BeforeModelCallback;
             registered.Add("before_model");
-            _workers.Add(NewWorker($"{agent.Name}_before_model", (args, _) =>
+            AddWorker(NewWorker($"{agent.Name}_before_model", (args, _) =>
             {
                 List<JsonElement>? messages = null;
                 if (args.TryGetValue("messages", out var msgEl) && msgEl.ValueKind == JsonValueKind.Array)
@@ -310,7 +266,7 @@ internal sealed class WorkerManager : IAsyncDisposable
         {
             var cb = agent.AfterModelCallback;
             registered.Add("after_model");
-            _workers.Add(NewWorker($"{agent.Name}_after_model", (args, _) =>
+            AddWorker(NewWorker($"{agent.Name}_after_model", (args, _) =>
             {
                 string? llmResult = args.TryGetValue("llm_result", out var resEl) && resEl.ValueKind == JsonValueKind.String
                     ? resEl.GetString()
@@ -352,7 +308,7 @@ internal sealed class WorkerManager : IAsyncDisposable
         {
             if (registered.Contains(position)) continue;
             var fns = delegates;
-            _workers.Add(NewWorker($"{agent.Name}_{position}", (args, _) =>
+            AddWorker(NewWorker($"{agent.Name}_{position}", (args, _) =>
             {
                 foreach (var fn in fns)
                 {
@@ -383,7 +339,7 @@ internal sealed class WorkerManager : IAsyncDisposable
                 // hand-off itself is detected by check_transfer, not this task.
                 // Unreachable-target behavior (allowed_transitions) is unchanged
                 // here — that gate lives in handoff_check below.
-                _workers.Add(NewWorker(toolName, (args, _) =>
+                AddWorker(NewWorker(toolName, (args, _) =>
                 {
                     var message = args.TryGetValue("message", out var msgEl) && msgEl.ValueKind == JsonValueKind.String
                         ? msgEl.GetString() ?? ""
@@ -398,7 +354,7 @@ internal sealed class WorkerManager : IAsyncDisposable
 
         foreach (var name in allNames)
         {
-            _workers.Add(NewWorker($"{name}_check_transfer", (args, _) =>
+            AddWorker(NewWorker($"{name}_check_transfer", (args, _) =>
             {
                 // First-wins: the swarm loop can only hand off to one agent per
                 // turn. Non-winning calls surface as dropped_transfers instead of
@@ -476,7 +432,7 @@ internal sealed class WorkerManager : IAsyncDisposable
 
         var handoffConditions = agent.Handoffs;
 
-        _workers.Add(NewWorker($"{agent.Name}_handoff_check", (args, _) =>
+        AddWorker(NewWorker($"{agent.Name}_handoff_check", (args, _) =>
         {
             var activeAgent = args.TryGetValue("active_agent", out var ae) ? ae.GetString() ?? "0" : "0";
             var isTransfer = args.TryGetValue("is_transfer", out var it) && IsTransferTruthy(it);
@@ -532,7 +488,7 @@ internal sealed class WorkerManager : IAsyncDisposable
         var nameToIdx = agent.Agents.Select((a, i) => (a.Name, Index: i.ToString()))
                                     .ToDictionary(t => t.Name, t => t.Index);
 
-        _workers.Add(NewWorker($"{agent.Name}_process_selection", (args, _) =>
+        AddWorker(NewWorker($"{agent.Name}_process_selection", (args, _) =>
         {
             string selected = "0";
             if (args.TryGetValue("human_output", out var ho))

--- a/docs/agents/api-reference.md
+++ b/docs/agents/api-reference.md
@@ -168,7 +168,7 @@ Built-in factories (all return `ToolDef`):
 
 **`RegexGuardrail.Create`** — `(string|IEnumerable<string> pattern(s), string mode = "block", string? name = null, string? message = null, Position position = Output, OnFail onFail = Retry, int maxRetries = 3)`. `mode`: `"block"` (fail on match) or `"allow"` (fail when nothing matches).
 
-**`LLMGuardrail.Create`** — `(string model, string policy, string? name = null, int? maxTokens = null, Position position = Output, OnFail onFail = Retry, int maxRetries = 3, string? apiKey = null)`.
+**`LLMGuardrail.Create`** — `(string model, string policy, string? name = null, int? maxTokens = null, Position position = Output, OnFail onFail = Retry, int maxRetries = 3)`. Evaluated server-side — no API key needed in-process.
 
 Enums: `Position` { `Input`, `Output` }; `OnFail` { `Retry`, `Raise`, `Fix`, `Human` }.
 

--- a/docs/agents/writing-agents.md
+++ b/docs/agents/writing-agents.md
@@ -306,6 +306,18 @@ Guardrails validate input or output and can retry, raise, fix, or escalate to a
 human. `Position` is `Input` or `Output`; `OnFail` is `Retry`, `Raise`, `Fix`, or
 `Human`.
 
+There are two kinds, evaluated in two different places:
+
+- **`RegexGuardrail.Create` / `LLMGuardrail.Create`** are data-only — no local code
+  runs them. The Conductor server evaluates the patterns (as an inline script) or
+  calls the model itself using its own configured LLM providers. No worker process,
+  HTTP client, or API key is needed in your application.
+- **Custom guardrails** (`[Guardrail]` methods via `GuardrailRegistry.FromInstance`)
+  run your own function. The SDK registers one combined worker per agent/tool scope
+  that evaluates all of that scope's custom guardrails — use these when the check
+  needs code you write (a database lookup, a call to an internal service, logic no
+  built-in type covers).
+
 `[Guardrail]` methods + `GuardrailRegistry.FromInstance`:
 
 ```csharp
@@ -326,7 +338,8 @@ var agent = new Agent("support_agent")
 };
 ```
 
-Regex guardrail (`mode: "block"` fails on a match, `"allow"` fails when nothing matches):
+Regex guardrail — evaluated server-side (`mode: "block"` fails on a match, `"allow"`
+fails when nothing matches):
 
 ```csharp
 var noEmails = RegexGuardrail.Create(
@@ -339,7 +352,8 @@ var noEmails = RegexGuardrail.Create(
     maxRetries: 3);
 ```
 
-LLM guardrail — a model judges content against a policy and returns `{passed, reason}`:
+LLM guardrail — evaluated server-side; the server calls the specified model with the
+policy + content and expects `{passed, reason}` back:
 
 ```csharp
 var safety = LLMGuardrail.Create(


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_

- Fix: `RegexGuardrail.Create` / `LLMGuardrail.Create` no longer evaluate client-side — they're
  data-only, and the Conductor server evaluates them natively (regex → GraalJS, LLM → its own
  configured providers)
- Removes the client-side LLM guardrail HTTP path (`HttpClient`, `OPENAI_API_KEY`), including a
  broken Anthropic branch that sent OpenAI-shaped requests to `api.anthropic.com` and always failed
- Custom `[Guardrail]` guardrails now combine into one worker per agent/tool scope
  (`{scope}_output_guardrail`) instead of one worker per guardrail, removing a same-name worker
  collision hazard
- Centralizes validation into `GuardrailDef.Validate`, closing a bypass where
  `GuardrailRegistry.FromInstance` skipped validation entirely
- Adds a dedup guard on worker registration (keyed by task type + domain) so no worker type can be
  registered twice
- Adds e2e coverage proving regex/LLM guardrails register no local worker, and that retry escalation
  actually fails a run instead of exhausting max turns
- **Breaking:** `LLMGuardrail.Create` drops its `apiKey` parameter; custom guardrail worker task
  names change from the guardrail's own name to `{scope}_output_guardrail`

| | Before | After |
|---|---|---|
| Regex / LLM guardrails | evaluated client-side, one worker per guardrail | evaluated server-side, no client worker |
| LLM guardrail HTTP path | `HttpClient` + `OPENAI_API_KEY`; Anthropic branch always failed | removed — server calls the model directly |
| Custom guardrail workers | one per guardrail, name collisions possible | one per agent/tool scope, deduped |
| `GuardrailRegistry.FromInstance` validation | skipped entirely | runs `GuardrailDef.Validate` |

Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_

- Keep `LLMGuardrail.Create`'s `apiKey` parameter for backward compatibility — dropped; the agent
  SDK has only ever shipped in the unreleased `3.0.0-rc2` tag, so there's no compatibility to
  preserve, and guardrails are meant to be server-driven end to end
- Keep one worker per guardrail — dropped in favor of the combined per-scope model already used by
  the Java/Python/TS SDKs
