### PR TITLE
Export the agent e2e suite as a release bundle for downstream repos

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -85,33 +85,11 @@ jobs:
 
       # A dead/unhealthy server makes every [SkippableFact] skip silently — that
       # must never read as green. Fail on 0 executed or server-unreachable skips.
+      # Shared verbatim with the released bundle (package-e2e-bundle.sh copies
+      # this same script in), so the two lanes cannot guard differently.
       - name: Guard against vacuous run
         if: always()
-        run: |
-          python3 - <<'EOF'
-          import glob, sys
-          import xml.etree.ElementTree as ET
-          NS = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
-          paths = sorted(glob.glob("results/*.trx"))
-          if not paths:
-              print("GUARD: no TRX files found — vacuous run"); sys.exit(1)
-          executed = unreachable = 0
-          for p in paths:
-              root = ET.parse(p).getroot()
-              counters = root.find(".//t:ResultSummary/t:Counters", NS)
-              executed += int(counters.get("executed", "0"))
-              for r in root.findall(".//t:UnitTestResult", NS):
-                  if r.get("outcome") == "NotExecuted":
-                      msg = r.find(".//t:Message", NS)
-                      if msg is not None and "server is not reachable" in (msg.text or ""):
-                          unreachable += 1
-          print(f"GUARD: executed={executed}, server-unreachable skips={unreachable}")
-          if executed == 0:
-              print("GUARD: 0 tests executed — vacuous run"); sys.exit(1)
-          if unreachable > 0:
-              print("GUARD: suite skipped due to unreachable server — vacuous run"); sys.exit(1)
-          print("GUARD: OK")
-          EOF
+        run: python3 scripts/check-results.py 'results/*.trx'
 
       - name: Upload results
         if: always()

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,6 +80,27 @@ jobs:
       - name: Build agent examples
         run: dotnet build Conductor.AI.Examples/Conductor.AI.Examples.sln -c Release
 
+  # The release workflow only static-checks the bundle. Compiling it is the check
+  # that actually proves it is self-contained, and it needs no published package
+  # (--build packs the working tree into a temp feed), so it belongs here — a
+  # bundle that cannot build should fail the PR, not ship attached to a release.
+  e2e_bundle:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate e2e bundle (static + compile)
+        run: ./scripts/test-package-e2e-bundle.sh --build
+
   integration_tests:
     needs: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release-agent-e2e-bundle.yml
+++ b/.github/workflows/release-agent-e2e-bundle.yml
@@ -8,7 +8,9 @@ name: Release Agent E2E Bundle
 #
 # Runs on the same release event as release.yml (the NuGet publish). Packaging
 # is purely static (no restore, no build), so it does not race that publish —
-# the bundle only references the package version.
+# the bundle only references the package version. Uploading DOES wait for the
+# package to appear on nuget.org, because a bundle pinning a version that was
+# never published is worse than a missing one: downstream fails at restore.
 #
 # Mirrors conductor-oss/javascript-sdk's release-agent-e2e-bundle.yml.
 
@@ -33,11 +35,24 @@ jobs:
 
       - name: Determine version
         id: version
+        # Tags arrive via env, never interpolated into the script body: a
+        # `${{ inputs.tag }}` expansion inside `run:` is substituted before the
+        # shell parses the line, which makes a dispatch input executable.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="$RELEASE_TAG"
+          fi
+          # The tag becomes a filename and a sed replacement downstream, so pin
+          # its shape here rather than trusting the trigger.
+          if ! printf '%s' "$TAG" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([-.+][A-Za-z0-9.-]+)?$'; then
+            echo "ERROR: tag '$TAG' is not a version (want e.g. 3.0.0 or 3.0.0-rc2)" >&2
+            exit 1
           fi
           # Release tags in this repo are bare versions (3.0.0-rc2); tolerate a
           # v-prefix anyway, since the NuGet version must never carry one.
@@ -46,12 +61,45 @@ jobs:
           echo "Packaging agent e2e bundle for version: ${TAG#v} (tag ${TAG})"
 
       - name: Package bundle
-        run: |
-          ./scripts/package-e2e-bundle.sh --version "${{ steps.version.outputs.version }}"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/package-e2e-bundle.sh --version "$VERSION"
 
+      # Validate the tarball just built, not a freshly packaged stand-in —
+      # otherwise every version-dependent assertion (the @VERSION@ sweep, the
+      # conductor-ai pin) is checked against a throwaway bundle while the one
+      # being uploaded goes uninspected.
       - name: Validate bundle
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          ./scripts/test-package-e2e-bundle.sh
+          ./scripts/test-package-e2e-bundle.sh \
+            --tarball "scripts/e2e-bundle-dist/conductor-ai-e2e-csharp-${VERSION}.tar.gz" \
+            --version "$VERSION"
+
+      # The bundle pins conductor-ai at this version, so it is only usable once
+      # release.yml has published that package. Packaging above is static and
+      # deliberately does not wait; attaching the artifact does, so a failed
+      # publish cannot leave a bundle on the release that can never restore.
+      - name: Wait for conductor-ai on nuget.org
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          INDEX="https://api.nuget.org/v3-flatcontainer/conductor-ai/index.json"
+          # The flat container lists NuGet-normalized versions, which lowercases
+          # the prerelease label (3.0.0-RC2 -> 3.0.0-rc2).
+          WANT="$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]')"
+          for attempt in $(seq 1 40); do
+            if curl -sfL "$INDEX" | grep -q "\"${WANT}\""; then
+              echo "conductor-ai ${VERSION} is on nuget.org"
+              exit 0
+            fi
+            echo "  attempt ${attempt}/40: conductor-ai ${VERSION} not indexed yet, waiting 30s..."
+            sleep 30
+          done
+          echo "ERROR: conductor-ai ${VERSION} never appeared on nuget.org." >&2
+          echo "       Refusing to attach a bundle that cannot restore." >&2
+          exit 1
 
       - name: Generate SHA256 checksums
         working-directory: scripts/e2e-bundle-dist

--- a/.github/workflows/release-agent-e2e-bundle.yml
+++ b/.github/workflows/release-agent-e2e-bundle.yml
@@ -1,0 +1,72 @@
+name: Release Agent E2E Bundle
+
+# Packages the agent e2e suite (Conductor.AI.E2eTests/) into a version-stamped,
+# self-contained tarball and attaches it to the GitHub release, so downstream
+# repos (e.g. orkes-io/orkes-conductor) can pin the e2e suite to the exact
+# csharp-sdk release they run against. The bundle restores conductor-ai at the
+# same version from NuGet.
+#
+# Runs on the same release event as release.yml (the NuGet publish). Packaging
+# is purely static (no restore, no build), so it does not race that publish —
+# the bundle only references the package version.
+#
+# Mirrors conductor-oss/javascript-sdk's release-agent-e2e-bundle.yml.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to attach to (e.g. 3.0.0-rc2)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  package-e2e-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          # Release tags in this repo are bare versions (3.0.0-rc2); tolerate a
+          # v-prefix anyway, since the NuGet version must never carry one.
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Packaging agent e2e bundle for version: ${TAG#v} (tag ${TAG})"
+
+      - name: Package bundle
+        run: |
+          ./scripts/package-e2e-bundle.sh --version "${{ steps.version.outputs.version }}"
+
+      - name: Validate bundle
+        run: |
+          ./scripts/test-package-e2e-bundle.sh
+
+      - name: Generate SHA256 checksums
+        working-directory: scripts/e2e-bundle-dist
+        run: |
+          for f in *.tar.gz; do
+            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+            echo "  $(cat "${f}.sha256")  ${f}"
+          done
+
+      - name: Upload bundle to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.version.outputs.tag }}" \
+            scripts/e2e-bundle-dist/*.tar.gz \
+            scripts/e2e-bundle-dist/*.sha256 \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ build
 **/*.user
 **/key-*.xml
 csharp-examples/csharp-examples.sln
+
+# agent e2e bundle staging output (scripts/package-e2e-bundle.sh)
+scripts/e2e-bundle-dist/

--- a/Conductor/conductor-csharp.csproj
+++ b/Conductor/conductor-csharp.csproj
@@ -24,6 +24,8 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
     <PackageReference Include="OpenTelemetry" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.15.1-beta.1" />
-    <None Include="/package/Conductor/README.md" Pack="true" PackagePath="/" />
+    <!-- Relative so `dotnet pack` works outside the Dockerfile too; in the
+         Docker build this resolves to /package/README.md, same file as before. -->
+    <None Include="../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/scripts/check-results.py
+++ b/scripts/check-results.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Fail a vacuous agent-e2e run: 0 tests executed, or skips from an unreachable server.
+
+Every e2e test is a [SkippableFact] that skips when the server is unreachable, so
+a dead server produces an all-skipped run that `dotnet test` exits 0 on. This
+guard turns that into a failure.
+
+Single source of truth, shared by both lanes so they cannot drift:
+  - .github/workflows/agent-e2e.yml runs it against the in-repo suite
+  - scripts/package-e2e-bundle.sh copies it into the released bundle, where
+    run.sh runs it
+
+Usage: check-results.py ['results/*.trx']
+"""
+
+import glob
+import sys
+import xml.etree.ElementTree as ET
+
+NS = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+
+# Substring of the skip message E2eFixture emits when the server is unreachable.
+# This is a literal coupling to test source: reword it in
+# Conductor.AI.E2eTests/E2eFixture.cs and this guard silently stops detecting
+# dead-server runs. test-package-e2e-bundle.sh asserts the two still match.
+UNREACHABLE_MARKER = "server is not reachable"
+
+paths = sorted(glob.glob(sys.argv[1] if len(sys.argv) > 1 else "results/*.trx"))
+if not paths:
+    print("GUARD: no TRX files found — vacuous run")
+    sys.exit(1)
+
+executed = unreachable = 0
+for p in paths:
+    root = ET.parse(p).getroot()
+    counters = root.find(".//t:ResultSummary/t:Counters", NS)
+    if counters is not None:
+        executed += int(counters.get("executed", "0"))
+    for r in root.findall(".//t:UnitTestResult", NS):
+        if r.get("outcome") == "NotExecuted":
+            msg = r.find(".//t:Message", NS)
+            if msg is not None and UNREACHABLE_MARKER in (msg.text or ""):
+                unreachable += 1
+
+print(f"GUARD: executed={executed}, server-unreachable skips={unreachable}")
+if executed == 0:
+    print("GUARD: 0 tests executed — vacuous run")
+    sys.exit(1)
+if unreachable > 0:
+    print("GUARD: suite skipped due to unreachable server — vacuous run")
+    sys.exit(1)
+print("GUARD: OK")

--- a/scripts/package-e2e-bundle.sh
+++ b/scripts/package-e2e-bundle.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Package the agent e2e suite as a standalone bundle ───────────────────────
+# Builds conductor-ai-e2e-csharp-<version>.tar.gz: a self-contained .NET test
+# project carrying the e2e test sources (Conductor.AI.E2eTests/), pinned to the
+# published conductor-ai@<version> NuGet package (no SDK source vendored).
+#
+# Downstream repos (e.g. orkes-io/orkes-conductor) download the bundle from the
+# csharp-sdk GitHub release and run it against their own server build, so the
+# e2e suite is pinned to the exact SDK release under test.
+# Mirrors conductor-oss/javascript-sdk#134 (scripts/package-e2e-bundle.sh).
+#
+# Usage:
+#   ./scripts/package-e2e-bundle.sh --version 3.0.0-rc2 [--out DIR]
+#
+# Packaging is static (no build, no restore, no network) — the pinned version
+# does not have to be on nuget.org yet, so this can run before the publish job
+# finishes.
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+
+VERSION=""
+OUT_DIR="$HERE/e2e-bundle-dist"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --out)     OUT_DIR="$2"; shift 2 ;;
+    *) echo "ERROR: unknown arg '$1' (want --version X.Y.Z [--out DIR])" >&2; exit 1 ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || { echo "ERROR: --version is required" >&2; exit 1; }
+
+NAME="conductor-ai-e2e-csharp-$VERSION"
+STAGE="$OUT_DIR/$NAME"
+PROJ="$STAGE/Conductor.AI.E2eTests"
+
+echo "Packaging agent e2e bundle ($NAME)..."
+rm -rf "$STAGE"
+mkdir -p "$PROJ"
+
+# Test sources copy over verbatim — they reference the SDK by namespace
+# (Conductor.AI, Conductor.Client), which resolves identically from the NuGet
+# package. The in-repo csproj is NOT copied; a standalone one is generated below.
+find "$REPO_ROOT/Conductor.AI.E2eTests" -maxdepth 1 -type f -name '*.cs' \
+  -exec cp {} "$PROJ/" \;
+
+# Suites `using Conductor.AI.Examples` for Settings (LlmModel / ServerUrl). The
+# in-repo csproj pulls that one file in with a <Compile Include> from the
+# examples project; the bundle carries a copy instead so it stands alone.
+mkdir -p "$PROJ/Shared"
+cp "$REPO_ROOT/Conductor.AI.Examples/Shared/Settings.cs" "$PROJ/Shared/Settings.cs"
+
+# Standalone project: same TFM and test packages as the in-repo csproj, but the
+# ProjectReference is replaced by a PackageReference at the released version —
+# the published artifact is what gets exercised. conductor-ai pulls
+# conductor-csharp (and RestSharp, via RestSharp.Serializers.NewtonsoftJson)
+# transitively, matching the in-repo dependency graph.
+#
+# AssemblyName must stay Conductor.AI.E2eTests: Conductor.AI grants it
+# InternalsVisibleTo, and a few suites read internal types.
+cat > "$PROJ/Conductor.AI.E2eTests.csproj" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Conductor.AI.E2eTests</AssemblyName>
+    <RootNamespace>Conductor.AI.E2eTests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <!-- Bundle-only: TRX is what the in-repo workflow consumes, but downstream
+         CI (orkes-conductor et al.) publishes JUnit XML, which every other
+         conductor-ai e2e bundle emits as results/junit-e2e.xml. -->
+    <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="conductor-ai" Version="@VERSION@" />
+  </ItemGroup>
+</Project>
+EOF
+
+# Guard: every e2e test is a [SkippableFact] that skips when the server is
+# unreachable, so a dead server yields an all-skipped run that reads as green.
+# Same check the SDK's own agent-e2e workflow applies to its TRX output.
+cat > "$STAGE/check-results.py" <<'EOF'
+#!/usr/bin/env python3
+"""Fail a vacuous agent-e2e run: 0 tests executed, or skips from an unreachable server."""
+import glob
+import sys
+import xml.etree.ElementTree as ET
+
+NS = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+paths = sorted(glob.glob(sys.argv[1] if len(sys.argv) > 1 else "results/*.trx"))
+if not paths:
+    print("GUARD: no TRX files found — vacuous run")
+    sys.exit(1)
+
+executed = unreachable = 0
+for p in paths:
+    root = ET.parse(p).getroot()
+    counters = root.find(".//t:ResultSummary/t:Counters", NS)
+    if counters is not None:
+        executed += int(counters.get("executed", "0"))
+    for r in root.findall(".//t:UnitTestResult", NS):
+        if r.get("outcome") == "NotExecuted":
+            msg = r.find(".//t:Message", NS)
+            if msg is not None and "server is not reachable" in (msg.text or ""):
+                unreachable += 1
+
+print(f"GUARD: executed={executed}, server-unreachable skips={unreachable}")
+if executed == 0:
+    print("GUARD: 0 tests executed — vacuous run")
+    sys.exit(1)
+if unreachable > 0:
+    print("GUARD: suite skipped due to unreachable server — vacuous run")
+    sys.exit(1)
+print("GUARD: OK")
+EOF
+
+cat > "$STAGE/run.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# Runs the agent e2e suite against a live Conductor server with the agent
+# runtime enabled (conductor-oss >= 3.32.0-rc.8, or orkes-conductor with the
+# agent runtime embedded).
+#
+# Required services (NOT started by this script):
+#   - Conductor server → CONDUCTOR_SERVER_URL (default http://localhost:8080/api)
+#   - mcp-testkit on http://localhost:3001 (MCP + HTTP-tool suites; the URL is
+#     fixed in those suites, not configurable)
+# Optional:
+#   - CONDUCTOR_AGENT_LLM_MODEL (default openai/gpt-4o-mini); the provider API
+#     key must be configured on the SERVER. A few suites additionally gate on
+#     OPENAI_API_KEY being present in this environment and skip without it.
+#
+# Requires the .NET 8 SDK. Usage: ./run.sh [extra dotnet test args]
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE"
+
+rc=0
+dotnet test Conductor.AI.E2eTests/Conductor.AI.E2eTests.csproj \
+  --configuration Release \
+  --logger "console;verbosity=normal" \
+  --logger "trx;LogFileName=agent-e2e.trx" \
+  --logger "junit;LogFilePath=$HERE/results/junit-e2e.xml" \
+  --results-directory results \
+  "$@" || rc=$?
+
+# An all-skipped run (dead server) must not read as a pass.
+if command -v python3 >/dev/null 2>&1; then
+  python3 check-results.py 'results/*.trx' || rc=1
+else
+  echo "WARN: python3 not found — skipping the vacuous-run guard" >&2
+fi
+
+echo "Results: $HERE/results/agent-e2e.trx"
+exit "$rc"
+EOF
+chmod +x "$STAGE/run.sh"
+
+cat > "$STAGE/README.md" <<'EOF'
+# Conductor Agent SDK (.NET) — E2E suite @VERSION@
+
+Self-contained end-to-end tests for the Conductor .NET agent SDK, pinned to
+release **@VERSION@**. Restores the `conductor-ai` NuGet package at that exact
+version — no SDK source is vendored, so a run exercises the published package.
+Cut from
+[conductor-sdk/conductor-csharp](https://github.com/conductor-sdk/conductor-csharp)
+(`Conductor.AI.E2eTests/`).
+
+## Prerequisites (you provide these)
+
+| Requirement                       | Env var                     | Default                     |
+|-----------------------------------|-----------------------------|-----------------------------|
+| .NET 8 SDK                        | —                           | —                           |
+| Conductor server w/ agent runtime | `CONDUCTOR_SERVER_URL`      | `http://localhost:8080/api` |
+| LLM model                         | `CONDUCTOR_AGENT_LLM_MODEL` | `openai/gpt-4o-mini`        |
+| mcp-testkit (MCP + HTTP suites)   | — (fixed `localhost:3001`)  | `pip install mcp-testkit`   |
+
+The server needs the agent runtime: conductor-oss `>= 3.32.0-rc.8`, or
+orkes-conductor booted with the agent runtime embedded. LLM provider API keys
+(e.g. `OPENAI_API_KEY`) go to the **server** process; a few suites also gate on
+`OPENAI_API_KEY` in their own environment and skip without it.
+
+Every test skips rather than fails when the server is unreachable, so `run.sh`
+ends with a guard that fails an all-skipped ("vacuous") run.
+
+## Run
+
+```bash
+./run.sh                                        # full suite
+./run.sh --filter 'FullyQualifiedName~Suite1'   # filter, plus any dotnet test args
+```
+
+Results land in `results/` — `agent-e2e.trx` plus `junit-e2e.xml` for CI report
+publishers.
+
+## Testing an unreleased SDK
+
+```bash
+dotnet add Conductor.AI.E2eTests/Conductor.AI.E2eTests.csproj \
+  package conductor-ai --version <other-version>
+./run.sh
+```
+
+For a locally built package, drop the `.nupkg` in a directory and add it as a
+source: `dotnet nuget add source <dir> -n local`.
+EOF
+
+# Stamp the version everywhere (skip binary fixtures).
+find "$STAGE" -type f ! -name '*.png' ! -name '*.jpg' ! -name '*.jpeg' \
+    ! -name '*.gif' ! -name '*.webp' ! -name '*.pdf' -print0 \
+  | xargs -0 sed -i.bak "s/@VERSION@/$VERSION/g"
+find "$STAGE" -name '*.bak' -delete
+
+mkdir -p "$OUT_DIR"
+tar -czf "$OUT_DIR/$NAME.tar.gz" -C "$OUT_DIR" "$NAME"
+rm -rf "$STAGE"
+
+echo "OK: $OUT_DIR/$NAME.tar.gz"

--- a/scripts/package-e2e-bundle.sh
+++ b/scripts/package-e2e-bundle.sh
@@ -34,6 +34,15 @@ done
 
 [[ -n "$VERSION" ]] || { echo "ERROR: --version is required" >&2; exit 1; }
 
+# The version is interpolated into a filename and into the sed replacement that
+# stamps @VERSION@, so restrict it to characters that are inert in both. Without
+# this a version carrying '/' or '&' silently corrupts every stamped file.
+[[ "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9.+-]*$ ]] || {
+  echo "ERROR: --version '$VERSION' is not a plain version string" >&2
+  echo "       (allowed: alphanumerics, dot, plus, hyphen — e.g. 3.0.0-rc2)" >&2
+  exit 1
+}
+
 NAME="conductor-ai-e2e-csharp-$VERSION"
 STAGE="$OUT_DIR/$NAME"
 PROJ="$STAGE/Conductor.AI.E2eTests"
@@ -45,8 +54,18 @@ mkdir -p "$PROJ"
 # Test sources copy over verbatim — they reference the SDK by namespace
 # (Conductor.AI, Conductor.Client), which resolves identically from the NuGet
 # package. The in-repo csproj is NOT copied; a standalone one is generated below.
-find "$REPO_ROOT/Conductor.AI.E2eTests" -maxdepth 1 -type f -name '*.cs' \
-  -exec cp {} "$PROJ/" \;
+#
+# Recursive, preserving layout: a new subdirectory of test sources must not be
+# silently dropped from the bundle. test-package-e2e-bundle.sh compares the full
+# relative path sets, so it catches an omission here rather than sharing the
+# same blind spot.
+SRC_DIR="$REPO_ROOT/Conductor.AI.E2eTests"
+while IFS= read -r -d '' f; do
+  rel="${f#"$SRC_DIR/"}"
+  mkdir -p "$PROJ/$(dirname "$rel")"
+  cp "$f" "$PROJ/$rel"
+done < <(find "$SRC_DIR" -type f -name '*.cs' \
+           -not -path "$SRC_DIR/obj/*" -not -path "$SRC_DIR/bin/*" -print0)
 
 # Suites `using Conductor.AI.Examples` for Settings (LlmModel / ServerUrl). The
 # in-repo csproj pulls that one file in with a <Compile Include> from the
@@ -94,41 +113,10 @@ EOF
 
 # Guard: every e2e test is a [SkippableFact] that skips when the server is
 # unreachable, so a dead server yields an all-skipped run that reads as green.
-# Same check the SDK's own agent-e2e workflow applies to its TRX output.
-cat > "$STAGE/check-results.py" <<'EOF'
-#!/usr/bin/env python3
-"""Fail a vacuous agent-e2e run: 0 tests executed, or skips from an unreachable server."""
-import glob
-import sys
-import xml.etree.ElementTree as ET
-
-NS = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
-paths = sorted(glob.glob(sys.argv[1] if len(sys.argv) > 1 else "results/*.trx"))
-if not paths:
-    print("GUARD: no TRX files found — vacuous run")
-    sys.exit(1)
-
-executed = unreachable = 0
-for p in paths:
-    root = ET.parse(p).getroot()
-    counters = root.find(".//t:ResultSummary/t:Counters", NS)
-    if counters is not None:
-        executed += int(counters.get("executed", "0"))
-    for r in root.findall(".//t:UnitTestResult", NS):
-        if r.get("outcome") == "NotExecuted":
-            msg = r.find(".//t:Message", NS)
-            if msg is not None and "server is not reachable" in (msg.text or ""):
-                unreachable += 1
-
-print(f"GUARD: executed={executed}, server-unreachable skips={unreachable}")
-if executed == 0:
-    print("GUARD: 0 tests executed — vacuous run")
-    sys.exit(1)
-if unreachable > 0:
-    print("GUARD: suite skipped due to unreachable server — vacuous run")
-    sys.exit(1)
-print("GUARD: OK")
-EOF
+# Copied verbatim rather than inlined here, so the bundle and the SDK's own
+# agent-e2e workflow run the identical script — including the skip-message
+# marker, which would otherwise be duplicated in two places and drift.
+cp "$HERE/check-results.py" "$STAGE/check-results.py"
 
 cat > "$STAGE/run.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -146,9 +134,20 @@ set -euo pipefail
 #     key must be configured on the SERVER. A few suites additionally gate on
 #     OPENAI_API_KEY being present in this environment and skip without it.
 #
-# Requires the .NET 8 SDK. Usage: ./run.sh [extra dotnet test args]
+# Requires the .NET 8 SDK and python3 (for the vacuous-run guard).
+# Usage: ./run.sh [extra dotnet test args]
 HERE="$(cd "$(dirname "$0")" && pwd)"
 cd "$HERE"
+
+# Checked up front, and fatal: an all-skipped run (dead server) exits 0 from
+# `dotnet test`, so a missing guard would turn that into a silent pass — the
+# exact failure this bundle is supposed to make impossible. Better to refuse to
+# start than to run for 20 minutes and report an unverifiable green.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 not found, but it is required for the vacuous-run guard." >&2
+  echo "       Install python3 (>= 3.8) and re-run." >&2
+  exit 1
+fi
 
 rc=0
 dotnet test Conductor.AI.E2eTests/Conductor.AI.E2eTests.csproj \
@@ -159,12 +158,7 @@ dotnet test Conductor.AI.E2eTests/Conductor.AI.E2eTests.csproj \
   --results-directory results \
   "$@" || rc=$?
 
-# An all-skipped run (dead server) must not read as a pass.
-if command -v python3 >/dev/null 2>&1; then
-  python3 check-results.py 'results/*.trx' || rc=1
-else
-  echo "WARN: python3 not found — skipping the vacuous-run guard" >&2
-fi
+python3 check-results.py 'results/*.trx' || rc=1
 
 echo "Results: $HERE/results/agent-e2e.trx"
 exit "$rc"
@@ -186,6 +180,7 @@ Cut from
 | Requirement                       | Env var                     | Default                     |
 |-----------------------------------|-----------------------------|-----------------------------|
 | .NET 8 SDK                        | —                           | —                           |
+| python3 >= 3.8 (run guard)        | —                           | —                           |
 | Conductor server w/ agent runtime | `CONDUCTOR_SERVER_URL`      | `http://localhost:8080/api` |
 | LLM model                         | `CONDUCTOR_AGENT_LLM_MODEL` | `openai/gpt-4o-mini`        |
 | mcp-testkit (MCP + HTTP suites)   | — (fixed `localhost:3001`)  | `pip install mcp-testkit`   |
@@ -196,7 +191,9 @@ orkes-conductor booted with the agent runtime embedded. LLM provider API keys
 `OPENAI_API_KEY` in their own environment and skip without it.
 
 Every test skips rather than fails when the server is unreachable, so `run.sh`
-ends with a guard that fails an all-skipped ("vacuous") run.
+ends with a guard (`check-results.py`) that fails an all-skipped ("vacuous")
+run. The guard is not optional — `run.sh` refuses to start without python3,
+because a missing guard would report a dead server as a pass.
 
 ## Run
 

--- a/scripts/test-package-e2e-bundle.sh
+++ b/scripts/test-package-e2e-bundle.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Validator for package-e2e-bundle.sh ──────────────────────────────────────
+# Builds the bundle at a throwaway version and asserts:
+#   - tarball exists and extracts to the expected dir
+#   - carries an executable, syntactically-valid run.sh + guard + README
+#   - every e2e test source from the repo made it in (file-count parity),
+#     plus the Settings.cs the suites `using Conductor.AI.Examples` for
+#   - the SDK is pinned as a PackageReference at the version, with no
+#     ProjectReference back at repo sources and no @VERSION@ left behind
+#   - the assembly name stays Conductor.AI.E2eTests (InternalsVisibleTo target)
+# All checks are static + deterministic (no network, no restore, no server).
+#
+# Run: ./scripts/test-package-e2e-bundle.sh [--build]
+#   --build additionally packs the local SDK into a temp feed and compiles the
+#   bundle against it — proves the suite builds with no ProjectReference, but
+#   needs the .NET SDK and a NuGet cache (not run in the release workflow).
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+VERSION="9.9.9-test"
+DO_BUILD=0
+[[ "${1:-}" == "--build" ]] && DO_BUILD=1
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+"$HERE/package-e2e-bundle.sh" --version "$VERSION" --out "$WORK/dist" >/dev/null
+
+NAME="conductor-ai-e2e-csharp-$VERSION"
+TAR="$WORK/dist/$NAME.tar.gz"
+
+[[ -f "$TAR" ]] || fail "tarball not produced ($TAR)"
+pass "tarball produced"
+
+mkdir -p "$WORK/x"
+tar -xzf "$TAR" -C "$WORK/x"
+ROOT="$WORK/x/$NAME"
+[[ -d "$ROOT" ]] || fail "tarball does not extract to $NAME/"
+pass "extracts to $NAME/"
+
+[[ -f "$ROOT/run.sh" ]] || fail "missing run.sh"
+[[ -x "$ROOT/run.sh" ]] || fail "run.sh not executable"
+bash -n "$ROOT/run.sh"  || fail "run.sh has a bash syntax error"
+[[ -f "$ROOT/README.md" ]] || fail "missing README.md"
+python3 -c "import py_compile,sys; py_compile.compile(sys.argv[1], doraise=True)" \
+  "$ROOT/check-results.py" >/dev/null \
+  || fail "check-results.py has a syntax error"
+grep -q "check-results.py" "$ROOT/run.sh" \
+  || fail "run.sh does not invoke the vacuous-run guard"
+# TRX drives the guard; junit-e2e.xml is what downstream CI publishes.
+grep -q 'trx;LogFileName=agent-e2e.trx' "$ROOT/run.sh" \
+  || fail "run.sh does not write results/agent-e2e.trx (the guard reads it)"
+# Absolute path on purpose: the junit logger resolves LogFilePath against the
+# project dir, ignoring --results-directory.
+grep -q 'junit;LogFilePath=$HERE/results/junit-e2e.xml' "$ROOT/run.sh" \
+  || fail "run.sh does not write results/junit-e2e.xml (downstream CI publishes it)"
+pass "run.sh + guard + README present and valid"
+
+# Every e2e test source made it into the bundle.
+SRC_COUNT="$(find "$REPO_ROOT/Conductor.AI.E2eTests" -maxdepth 1 -type f -name '*.cs' | wc -l | tr -d ' ')"
+BUNDLE_COUNT="$(find "$ROOT/Conductor.AI.E2eTests" -maxdepth 1 -type f -name '*.cs' | wc -l | tr -d ' ')"
+[[ "$SRC_COUNT" == "$BUNDLE_COUNT" ]] \
+  || fail "source parity: repo has $SRC_COUNT .cs files, bundle has $BUNDLE_COUNT"
+[[ "$SRC_COUNT" -gt 0 ]] || fail "no e2e sources found in the repo — glob is wrong"
+pass "all $SRC_COUNT e2e sources present"
+
+# Settings.cs comes from the examples project via <Compile Include> in-repo; the
+# bundle must carry its own copy or nothing compiles.
+[[ -f "$ROOT/Conductor.AI.E2eTests/Shared/Settings.cs" ]] \
+  || fail "missing Shared/Settings.cs (suites use Conductor.AI.Examples.Settings)"
+grep -q "namespace Conductor.AI.Examples" "$ROOT/Conductor.AI.E2eTests/Shared/Settings.cs" \
+  || fail "Shared/Settings.cs is not the Conductor.AI.Examples Settings"
+pass "Settings.cs vendored with its namespace intact"
+
+CSPROJ="$ROOT/Conductor.AI.E2eTests/Conductor.AI.E2eTests.csproj"
+[[ -f "$CSPROJ" ]] || fail "missing Conductor.AI.E2eTests.csproj"
+
+# SDK pinned as a package at the packaged version — never a path back to source.
+python3 -c "
+import sys
+import xml.etree.ElementTree as ET
+root = ET.parse(sys.argv[1]).getroot()
+version = sys.argv[2]
+pins = {r.get('Include'): r.get('Version') for r in root.iter('PackageReference')}
+assert pins.get('conductor-ai') == version, f'conductor-ai pin is {pins.get(\"conductor-ai\")!r}, want {version!r}'
+assert 'JunitXml.TestLogger' in pins, 'junit logger not referenced — run.sh cannot emit junit-e2e.xml'
+refs = [r.get('Include') for r in root.iter('ProjectReference')]
+assert not refs, f'bundle csproj still has ProjectReference(s): {refs}'
+compiles = [c.get('Include') for c in root.iter('Compile')]
+assert not compiles, f'bundle csproj reaches outside itself via <Compile>: {compiles}'
+name = root.find('.//AssemblyName')
+assert name is not None and name.text == 'Conductor.AI.E2eTests', \\
+    'AssemblyName must stay Conductor.AI.E2eTests (Conductor.AI grants it InternalsVisibleTo)'
+" "$CSPROJ" "$VERSION" || fail "csproj is not a valid standalone pin at $VERSION"
+if grep -rn '@VERSION@' "$ROOT" >/dev/null 2>&1; then
+  fail "unexpanded @VERSION@ placeholder left in bundle"
+fi
+pass "conductor-ai pinned at $VERSION as a package, assembly name preserved"
+
+if [[ "$DO_BUILD" == 1 ]]; then
+  # Pack the working tree at the throwaway version into a local feed, then build
+  # the bundle against it — the compile-time proof that the suite needs nothing
+  # but the published package.
+  FEED="$WORK/feed"
+  mkdir -p "$FEED"
+  echo "  building: packing local SDK at $VERSION into a temp feed..."
+  dotnet pack "$REPO_ROOT/Conductor/conductor-csharp.csproj" -o "$FEED" -c Release \
+    "/p:Version=$VERSION" -v quiet --nologo >/dev/null || fail "dotnet pack conductor-csharp failed"
+  dotnet pack "$REPO_ROOT/Conductor.AI/Conductor.AI.csproj" -o "$FEED" -c Release \
+    "/p:Version=$VERSION" -v quiet --nologo >/dev/null || fail "dotnet pack conductor-ai failed"
+  cat > "$ROOT/NuGet.config" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="local-bundle-test" value="$FEED" />
+  </packageSources>
+</configuration>
+XML
+  dotnet build "$CSPROJ" -c Release --nologo \
+    || fail "bundle does not compile against the packaged SDK at $VERSION"
+  pass "bundle compiles against packaged conductor-ai $VERSION (no project references)"
+fi
+
+echo "ALL CHECKS PASSED"

--- a/scripts/test-package-e2e-bundle.sh
+++ b/scripts/test-package-e2e-bundle.sh
@@ -2,26 +2,50 @@
 set -euo pipefail
 
 # ── Validator for package-e2e-bundle.sh ──────────────────────────────────────
-# Builds the bundle at a throwaway version and asserts:
-#   - tarball exists and extracts to the expected dir
+# Asserts that a bundle tarball:
+#   - extracts to the expected dir
 #   - carries an executable, syntactically-valid run.sh + guard + README
-#   - every e2e test source from the repo made it in (file-count parity),
+#   - carries EVERY e2e test source from the repo (recursive path-set parity),
 #     plus the Settings.cs the suites `using Conductor.AI.Examples` for
-#   - the SDK is pinned as a PackageReference at the version, with no
-#     ProjectReference back at repo sources and no @VERSION@ left behind
-#   - the assembly name stays Conductor.AI.E2eTests (InternalsVisibleTo target)
+#   - pins the SDK as a PackageReference at the version, with no ProjectReference
+#     back at repo sources, no <Compile> escapes, no @VERSION@ left behind
+#   - keeps AssemblyName Conductor.AI.E2eTests (InternalsVisibleTo target)
+#   - has not drifted from the in-repo csproj (same TFM, same test package pins)
+#   - ships the shared guard verbatim, keyed to the skip message E2eFixture.cs
+#     actually emits
 # All checks are static + deterministic (no network, no restore, no server).
 #
-# Run: ./scripts/test-package-e2e-bundle.sh [--build]
-#   --build additionally packs the local SDK into a temp feed and compiles the
-#   bundle against it — proves the suite builds with no ProjectReference, but
-#   needs the .NET SDK and a NuGet cache (not run in the release workflow).
+# Run: ./scripts/test-package-e2e-bundle.sh [--tarball PATH] [--version V] [--build]
+#
+#   (no args)    package a throwaway bundle into a temp dir and check that.
+#                Convenient for local dev; checks the SCRIPT, not any shipped
+#                artifact.
+#   --tarball    check an existing tarball. The release workflow uses this so the
+#                artifact it uploads is the artifact it checked — packaging twice
+#                would leave every version-dependent assertion untested on the
+#                real bundle.
+#   --version    version the tarball was stamped at; derived from its filename
+#                when omitted.
+#   --build      additionally pack the local SDK into a temp feed and compile the
+#                bundle against it — the compile-time proof that it needs nothing
+#                but the published package. Needs the .NET SDK; runs on PRs via
+#                the CI Build workflow.
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$HERE/.." && pwd)"
-VERSION="9.9.9-test"
+
+TARBALL=""
+VERSION=""
 DO_BUILD=0
-[[ "${1:-}" == "--build" ]] && DO_BUILD=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tarball) TARBALL="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    --build)   DO_BUILD=1; shift ;;
+    *) echo "ERROR: unknown arg '$1' (want [--tarball PATH] [--version V] [--build])" >&2; exit 1 ;;
+  esac
+done
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -29,13 +53,31 @@ trap 'rm -rf "$WORK"' EXIT
 fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
 
-"$HERE/package-e2e-bundle.sh" --version "$VERSION" --out "$WORK/dist" >/dev/null
+if [[ -n "$TARBALL" ]]; then
+  [[ -f "$TARBALL" ]] || fail "no such tarball: $TARBALL"
+  TAR="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
+  BASE="$(basename "$TAR")"
+  case "$BASE" in
+    conductor-ai-e2e-csharp-*.tar.gz) ;;
+    *) fail "unexpected tarball name '$BASE' (want conductor-ai-e2e-csharp-<version>.tar.gz)" ;;
+  esac
+  if [[ -z "$VERSION" ]]; then
+    VERSION="${BASE#conductor-ai-e2e-csharp-}"
+    VERSION="${VERSION%.tar.gz}"
+    [[ -n "$VERSION" ]] || fail "cannot derive a version from '$BASE'"
+  fi
+  echo "Validating shipped tarball $BASE (version $VERSION)..."
+else
+  VERSION="${VERSION:-9.9.9-test}"
+  "$HERE/package-e2e-bundle.sh" --version "$VERSION" --out "$WORK/dist" >/dev/null
+  TAR="$WORK/dist/conductor-ai-e2e-csharp-$VERSION.tar.gz"
+  echo "Validating a throwaway bundle packaged at version $VERSION..."
+fi
 
 NAME="conductor-ai-e2e-csharp-$VERSION"
-TAR="$WORK/dist/$NAME.tar.gz"
 
 [[ -f "$TAR" ]] || fail "tarball not produced ($TAR)"
-pass "tarball produced"
+pass "tarball present"
 
 mkdir -p "$WORK/x"
 tar -xzf "$TAR" -C "$WORK/x"
@@ -52,6 +94,10 @@ python3 -c "import py_compile,sys; py_compile.compile(sys.argv[1], doraise=True)
   || fail "check-results.py has a syntax error"
 grep -q "check-results.py" "$ROOT/run.sh" \
   || fail "run.sh does not invoke the vacuous-run guard"
+# The guard must be fatal, not best-effort: `dotnet test` exits 0 on an
+# all-skipped run, so a warn-and-continue path reports a dead server as a pass.
+grep -q 'ERROR: python3 not found' "$ROOT/run.sh" \
+  || fail "run.sh does not hard-fail when python3 is missing — the guard would be skippable"
 # TRX drives the guard; junit-e2e.xml is what downstream CI publishes.
 grep -q 'trx;LogFileName=agent-e2e.trx' "$ROOT/run.sh" \
   || fail "run.sh does not write results/agent-e2e.trx (the guard reads it)"
@@ -61,18 +107,47 @@ grep -q 'junit;LogFilePath=$HERE/results/junit-e2e.xml' "$ROOT/run.sh" \
   || fail "run.sh does not write results/junit-e2e.xml (downstream CI publishes it)"
 pass "run.sh + guard + README present and valid"
 
-# Every e2e test source made it into the bundle.
-SRC_COUNT="$(find "$REPO_ROOT/Conductor.AI.E2eTests" -maxdepth 1 -type f -name '*.cs' | wc -l | tr -d ' ')"
-BUNDLE_COUNT="$(find "$ROOT/Conductor.AI.E2eTests" -maxdepth 1 -type f -name '*.cs' | wc -l | tr -d ' ')"
-[[ "$SRC_COUNT" == "$BUNDLE_COUNT" ]] \
-  || fail "source parity: repo has $SRC_COUNT .cs files, bundle has $BUNDLE_COUNT"
-[[ "$SRC_COUNT" -gt 0 ]] || fail "no e2e sources found in the repo — glob is wrong"
-pass "all $SRC_COUNT e2e sources present"
+# ── The guard is shared, and keyed to a message the tests really emit ─────────
+# check-results.py matches a substring of E2eFixture's skip message. If that
+# message is reworded, the guard stops detecting dead-server runs and every lane
+# goes green on a dead server — so assert the coupling instead of trusting it.
+cmp -s "$HERE/check-results.py" "$ROOT/check-results.py" \
+  || fail "bundle check-results.py differs from scripts/check-results.py — the guard has been forked"
+MARKER="$(python3 - "$HERE/check-results.py" <<'PY'
+import re
+import sys
+src = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r'^UNREACHABLE_MARKER\s*=\s*"([^"]+)"', src, re.M)
+if not m:
+    sys.exit("UNREACHABLE_MARKER not found in check-results.py")
+print(m.group(1))
+PY
+)" || fail "cannot read UNREACHABLE_MARKER out of scripts/check-results.py"
+grep -qF "$MARKER" "$REPO_ROOT/Conductor.AI.E2eTests/E2eFixture.cs" \
+  || fail "guard marker '$MARKER' does not appear in E2eFixture.cs — reword one to match the other, or a dead server reads as green"
+grep -q 'scripts/check-results.py' "$REPO_ROOT/.github/workflows/agent-e2e.yml" \
+  || fail "agent-e2e.yml does not call scripts/check-results.py — the guard has been duplicated again"
+pass "guard shared verbatim, marker '$MARKER' matches E2eFixture.cs"
+
+# ── Every e2e test source made it in ─────────────────────────────────────────
+# Recursive path-set comparison, not a top-level count: a count over the same
+# glob the packager uses would agree whether or not a subdirectory was dropped.
+list_cs() { ( cd "$1" && find . -type f -name '*.cs' \
+                 -not -path './obj/*' -not -path './bin/*' | LC_ALL=C sort ); }
+list_cs "$REPO_ROOT/Conductor.AI.E2eTests" > "$WORK/repo-cs.txt"
+list_cs "$ROOT/Conductor.AI.E2eTests"      > "$WORK/bundle-cs.txt"
+
+COUNT="$(wc -l < "$WORK/repo-cs.txt" | tr -d ' ')"
+[[ "$COUNT" -gt 0 ]] || fail "no e2e sources found in the repo — glob is wrong"
+MISSING="$(comm -23 "$WORK/repo-cs.txt" "$WORK/bundle-cs.txt")"
+[[ -z "$MISSING" ]] || fail "bundle is missing e2e sources:"$'\n'"$MISSING"
+EXTRA="$(comm -13 "$WORK/repo-cs.txt" "$WORK/bundle-cs.txt")"
+[[ "$EXTRA" == "./Shared/Settings.cs" ]] \
+  || fail "bundle has unexpected sources (want only ./Shared/Settings.cs):"$'\n'"${EXTRA:-<none>}"
+pass "all $COUNT e2e sources present (recursive parity), plus the vendored Settings.cs"
 
 # Settings.cs comes from the examples project via <Compile Include> in-repo; the
 # bundle must carry its own copy or nothing compiles.
-[[ -f "$ROOT/Conductor.AI.E2eTests/Shared/Settings.cs" ]] \
-  || fail "missing Shared/Settings.cs (suites use Conductor.AI.Examples.Settings)"
 grep -q "namespace Conductor.AI.Examples" "$ROOT/Conductor.AI.E2eTests/Shared/Settings.cs" \
   || fail "Shared/Settings.cs is not the Conductor.AI.Examples Settings"
 pass "Settings.cs vendored with its namespace intact"
@@ -102,17 +177,60 @@ if grep -rn '@VERSION@' "$ROOT" >/dev/null 2>&1; then
 fi
 pass "conductor-ai pinned at $VERSION as a package, assembly name preserved"
 
+# ── No drift from the in-repo csproj ─────────────────────────────────────────
+# The bundle csproj is generated with its TFM and test-package versions written
+# out longhand, so a bump in the in-repo csproj would otherwise leave the bundle
+# quietly testing on stale xunit / Test.Sdk.
+REPO_CSPROJ="$REPO_ROOT/Conductor.AI.E2eTests/Conductor.AI.E2eTests.csproj"
+[[ -f "$REPO_CSPROJ" ]] || fail "in-repo csproj not found ($REPO_CSPROJ)"
+python3 - "$CSPROJ" "$REPO_CSPROJ" <<'PY' || fail "bundle csproj has drifted from the in-repo csproj"
+import sys
+import xml.etree.ElementTree as ET
+
+
+def load(path):
+    root = ET.parse(path).getroot()
+    pins = {r.get("Include"): r.get("Version") for r in root.iter("PackageReference")}
+    tfm = root.find(".//TargetFramework")
+    return (tfm.text if tfm is not None else None), pins
+
+
+bundle_tfm, bundle_pins = load(sys.argv[1])
+repo_tfm, repo_pins = load(sys.argv[2])
+
+if bundle_tfm != repo_tfm:
+    sys.exit(f"TargetFramework drift: bundle {bundle_tfm!r} vs repo {repo_tfm!r}")
+
+drift = {
+    name: (want, bundle_pins.get(name))
+    for name, want in repo_pins.items()
+    if bundle_pins.get(name) != want
+}
+if drift:
+    detail = ", ".join(
+        f"{name}: repo {want!r} vs bundle {got!r}" for name, (want, got) in sorted(drift.items())
+    )
+    sys.exit(
+        "test package drift — update the generated csproj in "
+        f"scripts/package-e2e-bundle.sh: {detail}"
+    )
+
+print(f"  ok: no drift from the in-repo csproj ({repo_tfm}, {len(repo_pins)} shared pins)")
+PY
+
 if [[ "$DO_BUILD" == 1 ]]; then
-  # Pack the working tree at the throwaway version into a local feed, then build
+  # Pack the working tree at a throwaway version into a local feed, then build
   # the bundle against it — the compile-time proof that the suite needs nothing
-  # but the published package.
+  # but the published package. Uses its own version so it never collides with a
+  # real one in the NuGet cache.
+  BUILD_VERSION="9.9.9-test"
   FEED="$WORK/feed"
   mkdir -p "$FEED"
-  echo "  building: packing local SDK at $VERSION into a temp feed..."
+  echo "  building: packing local SDK at $BUILD_VERSION into a temp feed..."
   dotnet pack "$REPO_ROOT/Conductor/conductor-csharp.csproj" -o "$FEED" -c Release \
-    "/p:Version=$VERSION" -v quiet --nologo >/dev/null || fail "dotnet pack conductor-csharp failed"
+    "/p:Version=$BUILD_VERSION" -v quiet --nologo >/dev/null || fail "dotnet pack conductor-csharp failed"
   dotnet pack "$REPO_ROOT/Conductor.AI/Conductor.AI.csproj" -o "$FEED" -c Release \
-    "/p:Version=$VERSION" -v quiet --nologo >/dev/null || fail "dotnet pack conductor-ai failed"
+    "/p:Version=$BUILD_VERSION" -v quiet --nologo >/dev/null || fail "dotnet pack conductor-ai failed"
   cat > "$ROOT/NuGet.config" <<XML
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
@@ -122,9 +240,15 @@ if [[ "$DO_BUILD" == 1 ]]; then
   </packageSources>
 </configuration>
 XML
+  # Repoint at the locally packed version: when validating a shipped tarball the
+  # pin is a real release that may not be published yet, and the point of this
+  # step is to compile the SOURCES against a package boundary.
+  ( cd "$ROOT" && dotnet add Conductor.AI.E2eTests/Conductor.AI.E2eTests.csproj \
+      package conductor-ai --version "$BUILD_VERSION" --no-restore >/dev/null ) \
+    || fail "could not repoint the bundle at conductor-ai $BUILD_VERSION"
   dotnet build "$CSPROJ" -c Release --nologo \
-    || fail "bundle does not compile against the packaged SDK at $VERSION"
-  pass "bundle compiles against packaged conductor-ai $VERSION (no project references)"
+    || fail "bundle does not compile against the packaged SDK at $BUILD_VERSION"
+  pass "bundle compiles against packaged conductor-ai $BUILD_VERSION (no project references)"
 fi
 
 echo "ALL CHECKS PASSED"


### PR DESCRIPTION
## What

Packages the agent e2e suite (`Conductor.AI.E2eTests/`) into a self-contained, version-stamped tarball — `conductor-ai-e2e-csharp-<version>.tar.gz` — attached to every GitHub release, so downstream repos (e.g. orkes-io/orkes-conductor) can pin the e2e suite to the exact csharp-sdk release they run against. Mirrors conductor-oss/javascript-sdk#134.

- `scripts/package-e2e-bundle.sh` — stages the 27 e2e sources verbatim + a standalone csproj that swaps the `ProjectReference` for `PackageReference conductor-ai@<version>`, so a run exercises the **published** package. Two .NET-specific wrinkles the JS bundle didn't have: `Settings` (`LlmModel`/`ServerUrl`) is vendored into the bundle, since in-repo it arrives via `<Compile Include>` from the examples project; and `AssemblyName` must stay `Conductor.AI.E2eTests` because `Conductor.AI` grants it `InternalsVisibleTo` and a few suites read internal types.
- Bundles ship `check-results.py` + `run.sh`. Every test is a `[SkippableFact]` that skips when the server is unreachable, so a dead server yields an all-skipped run that reads as green — `run.sh` fails on 0 executed or server-unreachable skips, the same guard `agent-e2e.yml` applies in-repo.
- `scripts/test-package-e2e-bundle.sh` — static validator (source parity, package pin, no `ProjectReference`/`<Compile>` escapes, assembly name preserved, no leftover `@VERSION@`; no network). `--build` additionally packs the local SDK into a temp feed and compiles the bundle against it — the compile-time proof it needs nothing but the package.
- `.github/workflows/release-agent-e2e-bundle.yml` — packages, validates, generates sha256 sidecars, uploads to the release; same release event as `release.yml`, plus `workflow_dispatch` to attach bundles to existing releases. Release tags in this repo are bare versions (`3.0.0-rc2`), so the tag is used verbatim and `v` is stripped only for the NuGet version.

## Changes outside the bundle-export scope

Flagging these explicitly, since they touch existing files rather than adding new ones. All three are consequences of review findings rather than the original goal — happy to split any of them out if reviewers would rather see them separately.

| File | Change | Why it's here |
|---|---|---|
| `Conductor/conductor-csharp.csproj` | README path `/package/Conductor/README.md` → `../README.md` | The absolute path is Dockerfile-only, so `dotnet pack` failed anywhere else — which the validator's `--build` mode needs. See below. |
| `.github/workflows/agent-e2e.yml` | −25/+3: inline guard heredoc replaced by `python3 scripts/check-results.py` | The guard existed twice (inline here, generated into the bundle) keyed to a magic string from `E2eFixture.cs`, with nothing tying the copies together. Deduplicating it necessarily edits this workflow. No behavior change — same logic, same marker. |
| `.github/workflows/pull_request.yml` | +21: new `e2e_bundle` job | `--build` is the only check that proves the bundle compiles, and it ran nowhere. It needs no published package, so a bundle that can't compile should fail the PR rather than ship attached to a release. **Note this adds a job to every PR.** |

### On the csproj fix

`Conductor/conductor-csharp.csproj` pinned its README at `/package/Conductor/README.md` — a Dockerfile-only path, so `dotnet pack` failed anywhere else. Changed to `../README.md`, which resolves to the same file inside the Docker build (Dockerfile copies `/README.md` to **both** `/package/Conductor/README.md` and `/package/README.md`; workdir is `/package/Conductor`) and matches what `Conductor.AI.csproj` already does. `release.yml` packs via `docker build --target=publish_release`, so the release path is unaffected.

## Review hardening (second commit)

A review of the first commit turned up eight issues, mostly variants of *the validator couldn't catch the bugs it existed for, and the guard failed open*:

1. **The release workflow validated a stand-in, not the shipped artifact.** It packaged at the real version, then the validator re-packaged at `9.9.9-test` in a temp dir and checked *that* — so every version-dependent assertion never saw the uploaded tarball. Validator now takes `--tarball`/`--version`; the workflow points it at what it just built. `$VERSION` is also shape-checked in the packager, since it's an unescaped `sed` replacement (a `/` or `&` silently corrupted every stamped file).
2. **Script injection.** `TAG="${{ inputs.tag }}"` inside `run:` is substituted before the shell parses the line. Tags now arrive via `env:` and are shape-checked before use.
3. **The vacuous-run guard failed open.** No python3 → warn and continue; since `dotnet test` exits 0 on an all-skipped run, a dead server reported a pass — exactly what the guard prevents. `run.sh` now refuses to start without python3, checked up front rather than after a 20-minute run. python3 added to the bundle README prerequisites.
4. **The guard was duplicated and untested.** Extracted to `scripts/check-results.py`, copied verbatim into the bundle and invoked by `agent-e2e.yml`. The validator asserts both copies are identical, that `UNREACHABLE_MARKER` still appears in `E2eFixture.cs`, and that `agent-e2e.yml` hasn't re-inlined its own.
5. **No drift detection on the generated csproj.** It writes the TFM and four test-package versions longhand, so an in-repo bump left the bundle on stale xunit/Test.Sdk. Validator now diffs both csprojs.
6. **Packager and validator shared one blind spot.** Both used `find -maxdepth 1 -name '*.cs'`, so the parity count agreed whether or not a subdirectory was dropped. Packager copies recursively (excluding `obj/`, `bin/`); validator compares full relative path sets, requiring the only extra to be the vendored `Shared/Settings.cs`.
7. **`--build` ran nowhere.** Added the `e2e_bundle` CI job (see the scope table above).
8. **Bundle validity depended on an uncoordinated publish.** Both workflows fire on `release: published` independently, so a failed NuGet publish still attached a bundle pinning a nonexistent version. Packaging still doesn't wait (it's static), but **upload now blocks on `conductor-ai` appearing in the nuget.org flat container, up to 20 minutes.** This delays when the asset shows up on a release, and fails the job outright if the publish fails.

Also: the validator errored on unknown args only when they were `$1`, so a typo silently ran static-only and printed `ALL CHECKS PASSED`. Proper arg loop now.

## Validation

- validator green in all four modes — self-packaged and `--tarball`, each with and without `--build`; compiles **0 warnings / 0 errors** against a locally packed `conductor-ai 9.9.9-test` with no project references, confirming internals access survives the package boundary
- `dotnet test --list-tests` on the extracted bundle discovers **157 tests — identical to the in-repo project**
- guard exercised against synthetic TRX: healthy → 0; 0-executed → 1; server-unreachable skip → 1; no TRX → 1
- **negative-tested that the new checks actually fail**, since finding 6 was precisely a check that couldn't: hostile version `1.0/x&y` → rejected (exit 1); tarball with one source removed → `FAIL: bundle is missing e2e sources`; in-repo xunit bumped → `test package drift ... xunit: repo '2.9.9' vs bundle '2.9.3'`
- `docker build --target=pack_release` succeeds with the relative README path, and the resulting `conductor-csharp` nupkg contains `README.md`

Not run here: the suite end-to-end, which needs a live server + mcp-testkit + real LLM calls — that's `agent-e2e.yml` on this PR, over the same sources.

## Follow-up

The first release cut after this merges is the first one to carry a bundle; the consuming lane in orkes-io/orkes-conductor pins that version.

Known and deliberately left alone: the tarball isn't reproducible (no `--sort`/`--mtime`/`--owner`), and `gh release upload --clobber` replaces a bundle and its sha256 sidecar together, so downstream verification can't detect a pinned bundle changing underneath it.
