### PR TITLE
fix(scheduler): fall back from PUT to GET on pause/resume 405

### DIFF
--- a/Conductor.AI.Examples/93_SchedulerVerbFallback/Example93SchedulerVerbFallback.csproj
+++ b/Conductor.AI.Examples/93_SchedulerVerbFallback/Example93SchedulerVerbFallback.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Conductor/conductor-csharp.csproj" />
+  </ItemGroup>
+</Project>

--- a/Conductor.AI.Examples/93_SchedulerVerbFallback/Program.cs
+++ b/Conductor.AI.Examples/93_SchedulerVerbFallback/Program.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+// Scheduler pause/resume verb fallback.
+//
+// OSS/embedded Conductor accepts PUT for schedule pause/resume; Orkes Conductor historically
+// accepted only GET. SchedulerResourceApi.PauseSchedule/ResumeSchedule send PUT first and fall
+// back to GET only on an HTTP 405. Point CONDUCTOR_SERVER_URL at either server family and set a
+// breakpoint in SchedulerResourceApi.ExecuteStateChange to step through it.
+//
+// Usage:
+//   CONDUCTOR_SERVER_URL=http://localhost:8080/api \
+//   dotnet run --project sdk/csharp/examples/93_SchedulerVerbFallback/Example93SchedulerVerbFallback.csproj [scheduleName]
+
+using Conductor.Api;
+using Conductor.Client.Models;
+
+var serverUrl = Environment.GetEnvironmentVariable("CONDUCTOR_SERVER_URL") ?? "http://localhost:8080/api";
+var scheduleName = args.Length > 0 ? args[0] : "demo-schedule";
+
+Console.WriteLine($"Server:   {serverUrl}");
+Console.WriteLine($"Schedule: {scheduleName}");
+
+var client = new SchedulerResourceApi(serverUrl);
+
+Console.WriteLine("\nCreating schedule...");
+client.SaveSchedule(new SaveScheduleRequest(
+    cronExpression: "0 0 9 * * *",
+    name: scheduleName,
+    startWorkflowRequest: new StartWorkflowRequest(name: "demo_workflow")));
+Console.WriteLine("✓ Created");
+
+Console.WriteLine("\nPausing...");
+client.PauseSchedule(scheduleName);
+Console.WriteLine("✓ Paused");
+
+Console.WriteLine("\nResuming...");
+client.ResumeSchedule(scheduleName);
+Console.WriteLine("✓ Resumed");
+
+Console.WriteLine("\nDeleting schedule...");
+client.DeleteSchedule(scheduleName);
+Console.WriteLine("✓ Deleted");

--- a/Conductor.AI.Examples/Conductor.AI.Examples.sln
+++ b/Conductor.AI.Examples/Conductor.AI.Examples.sln
@@ -221,6 +221,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example91Skills", "91_Skill
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example92ScheduledAgent", "92_ScheduledAgent\Example92ScheduledAgent.csproj", "{8A2FB1CD-F4E6-450D-8552-971EF743A257}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example93SchedulerVerbFallback", "93_SchedulerVerbFallback\Example93SchedulerVerbFallback.csproj", "{5DB67614-46E2-49E2-B2F1-9872814942D7}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleAdk00HelloWorld", "Adk00_HelloWorld\ExampleAdk00HelloWorld.csproj", "{F9687D59-56E8-4D53-9039-73BAABE7682F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleAdk01BasicAgent", "Adk01_BasicAgent\ExampleAdk01BasicAgent.csproj", "{BAC26D41-E5F3-45D4-9ED1-7788EFAE6235}"
@@ -806,6 +808,10 @@ Global
 		{8A2FB1CD-F4E6-450D-8552-971EF743A257}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A2FB1CD-F4E6-450D-8552-971EF743A257}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8A2FB1CD-F4E6-450D-8552-971EF743A257}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DB67614-46E2-49E2-B2F1-9872814942D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DB67614-46E2-49E2-B2F1-9872814942D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DB67614-46E2-49E2-B2F1-9872814942D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DB67614-46E2-49E2-B2F1-9872814942D7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F9687D59-56E8-4D53-9039-73BAABE7682F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F9687D59-56E8-4D53-9039-73BAABE7682F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9687D59-56E8-4D53-9039-73BAABE7682F}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Conductor.AI.Examples/README.md
+++ b/Conductor.AI.Examples/README.md
@@ -1,6 +1,6 @@
 # Conductor AI Agent Examples (.NET)
 
-175 self-contained example projects for the `conductor-ai` agent layer. Each directory is
+176 self-contained example projects for the `conductor-ai` agent layer. Each directory is
 its own `.csproj` with a single `Program.cs`, and a header comment listing the environment
 variables it needs.
 
@@ -28,7 +28,7 @@ buildable. CI does **not** execute them.
 
 | Prefix | Count | Covers |
 |---|---|---|
-| `01`–`115` | 109 | The native agent API |
+| `01`–`115` | 110 | The native agent API |
 | `Adk*` | 36 | Google ADK adapter |
 | `Sk*` | 20 | Semantic Kernel adapter |
 | `OpenAi*` | 10 | OpenAI Agents adapter |
@@ -56,6 +56,7 @@ Numbering is roughly thematic and increases in complexity. Suffixed variants (`0
 | Observability | `26_OpenTelemetryTracing`, `80_LiveDashboard` |
 | Skills | `91_Skills` |
 | Schedules | `92_ScheduledAgent` |
+| Scheduler pause/resume verb fallback | `93_SchedulerVerbFallback` |
 
 ## Examples with extra prerequisites
 

--- a/Conductor.AI.Tests/SchedulesVerbFallbackTests.cs
+++ b/Conductor.AI.Tests/SchedulesVerbFallbackTests.cs
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Conductor.AI.Scheduling;
+using Xunit;
+
+namespace Conductor.AI.Tests;
+
+public class SchedulesVerbFallbackTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, (HttpStatusCode, string)> _respond;
+        public readonly List<string> Requests = new();
+        public StubHandler(Func<HttpRequestMessage, (HttpStatusCode, string)> respond) => _respond = respond;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Requests.Add($"{request.Method} {request.RequestUri!.PathAndQuery}");
+            var (code, body) = _respond(request);
+            return Task.FromResult(new HttpResponseMessage(code)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    [Fact]
+    public async Task PauseAsync_SendsPutFirst()
+    {
+        var handler = new StubHandler(_ => (HttpStatusCode.OK, "{}"));
+        var schedules = new Schedules(new HttpClient(handler), "http://localhost:8080");
+
+        await schedules.PauseAsync("digest-daily");
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("PUT /scheduler/schedules/digest-daily/pause", request);
+    }
+
+    [Fact]
+    public async Task PauseAsync_FallsBackToGetOn405()
+    {
+        var handler = new StubHandler(req => req.Method == HttpMethod.Put
+            ? (HttpStatusCode.MethodNotAllowed, "")
+            : (HttpStatusCode.OK, "{}"));
+        var schedules = new Schedules(new HttpClient(handler), "http://localhost:8080");
+
+        await schedules.PauseAsync("digest-daily");
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("PUT /scheduler/schedules/digest-daily/pause", handler.Requests[0]);
+        Assert.Equal("GET /scheduler/schedules/digest-daily/pause", handler.Requests[1]);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_FallsBackToGetOn405Independently_EachCallRetriesPutFirst()
+    {
+        var handler = new StubHandler(req => req.Method == HttpMethod.Put
+            ? (HttpStatusCode.MethodNotAllowed, "")
+            : (HttpStatusCode.OK, "{}"));
+        var schedules = new Schedules(new HttpClient(handler), "http://localhost:8080");
+
+        await schedules.PauseAsync("digest-daily");
+        await schedules.ResumeAsync("digest-daily");
+
+        Assert.Equal(4, handler.Requests.Count);
+        Assert.Equal("PUT /scheduler/schedules/digest-daily/resume", handler.Requests[2]);
+        Assert.Equal("GET /scheduler/schedules/digest-daily/resume", handler.Requests[3]);
+    }
+
+    [Fact]
+    public async Task PauseAsync_ReasonSurvivesTheGetFallback()
+    {
+        var handler = new StubHandler(req => req.Method == HttpMethod.Put
+            ? (HttpStatusCode.MethodNotAllowed, "")
+            : (HttpStatusCode.OK, "{}"));
+        var schedules = new Schedules(new HttpClient(handler), "http://localhost:8080");
+
+        await schedules.PauseAsync("digest-daily", reason: "maintenance");
+
+        Assert.Contains(handler.Requests, r => r == "GET /scheduler/schedules/digest-daily/pause?reason=maintenance");
+    }
+
+    [Fact]
+    public async Task PauseAsync_RethrowsOn403WithoutFallingBackToGet()
+    {
+        var handler = new StubHandler(_ => (HttpStatusCode.Forbidden, ""));
+        var schedules = new Schedules(new HttpClient(handler), "http://localhost:8080");
+
+        await Assert.ThrowsAsync<ScheduleException>(() => schedules.PauseAsync("digest-daily"));
+
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_FallsBackToGetOn405()
+    {
+        var handler = new StubHandler(req => req.Method == HttpMethod.Put
+            ? (HttpStatusCode.MethodNotAllowed, "")
+            : (HttpStatusCode.OK, "{}"));
+        var schedules = new Schedules(new HttpClient(handler), "http://localhost:8080");
+
+        await schedules.ResumeAsync("digest-daily");
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("PUT /scheduler/schedules/digest-daily/resume", handler.Requests[0]);
+        Assert.Equal("GET /scheduler/schedules/digest-daily/resume", handler.Requests[1]);
+    }
+}

--- a/Conductor.AI/Scheduling/Schedules.cs
+++ b/Conductor.AI/Scheduling/Schedules.cs
@@ -89,13 +89,13 @@ public sealed class Schedules
     {
         var path = $"/scheduler/schedules/{Uri.EscapeDataString(wireName)}/pause";
         if (reason is not null) path += $"?reason={Uri.EscapeDataString(reason)}";
-        await RequestAsync(HttpMethod.Put, path, null, ct);
+        await ExecuteStateChangeAsync(path, ct);
     }
 
     public async Task ResumeAsync(string wireName, CancellationToken ct = default)
     {
-        await RequestAsync(HttpMethod.Put,
-            $"/scheduler/schedules/{Uri.EscapeDataString(wireName)}/resume", null, ct);
+        await ExecuteStateChangeAsync(
+            $"/scheduler/schedules/{Uri.EscapeDataString(wireName)}/resume", ct);
     }
 
     public async Task DeleteAsync(string wireName, CancellationToken ct = default)
@@ -310,25 +310,37 @@ public sealed class Schedules
 
     private async Task<JsonNode?> RequestAsync(HttpMethod method, string path, JsonNode? body, CancellationToken ct)
     {
-        int statusCode;
-        string? text;
+        var (statusCode, text) = await SendAsync(method, path, body, ct);
+        return Translate(statusCode, text);
+    }
 
+    private async Task ExecuteStateChangeAsync(string path, CancellationToken ct)
+    {
+        var (statusCode, text) = await SendAsync(HttpMethod.Put, path, null, ct);
+        if (statusCode == (int)HttpStatusCode.MethodNotAllowed)
+            (statusCode, text) = await SendAsync(HttpMethod.Get, path, null, ct);
+        Translate(statusCode, text);
+    }
+
+    private async Task<(int StatusCode, string? Text)> SendAsync(
+        HttpMethod method, string path, JsonNode? body, CancellationToken ct)
+    {
         if (_configuration is not null)
-        {
-            (statusCode, text) = await AgentApiCall.InvokeAsync(_configuration, ToRestSharpMethod(method), path, body, ct);
-        }
-        else
-        {
-            var url = $"{_baseUrl}{path}";
-            using var req = new HttpRequestMessage(method, url);
-            if (body is not null)
-                req.Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json");
+            return await AgentApiCall.InvokeAsync(_configuration, ToRestSharpMethod(method), path, body, ct);
 
-            using var resp = await _client!.SendAsync(req, ct);
-            statusCode = (int)resp.StatusCode;
-            text = await resp.Content.ReadAsStringAsync(ct);
-        }
+        var url = $"{_baseUrl}{path}";
+        using var req = new HttpRequestMessage(method, url);
+        if (body is not null)
+            req.Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json");
 
+        using var resp = await _client!.SendAsync(req, ct);
+        var statusCode = (int)resp.StatusCode;
+        var text = await resp.Content.ReadAsStringAsync(ct);
+        return (statusCode, text);
+    }
+
+    private static JsonNode? Translate(int statusCode, string? text)
+    {
         if (statusCode < 200 || statusCode >= 300)
         {
             if (statusCode == (int)HttpStatusCode.NotFound)

--- a/Conductor/Api/SchedulerResourceApi.cs
+++ b/Conductor/Api/SchedulerResourceApi.cs
@@ -775,8 +775,52 @@ namespace Conductor.Api
                 ExceptionFactory, "PauseAllSchedules");
         }
 
+        private ApiResponse<Object> ExecuteStateChange(
+            string localVarPath, List<KeyValuePair<String, String>> localVarQueryParams, Object localVarPostBody,
+            Dictionary<String, String> localVarHeaderParams, Dictionary<String, String> localVarFormParams,
+            Dictionary<String, FileParameter> localVarFileParams, Dictionary<String, String> localVarPathParams,
+            String localVarHttpContentType, string operationName)
+        {
+            try
+            {
+                return this.Configuration.ApiClient.Execute<Object>(localVarPath,
+                    Method.Put, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
+                    localVarFileParams, localVarPathParams, localVarHttpContentType, this.Configuration,
+                    ExceptionFactory, operationName);
+            }
+            catch (ApiException e) when (e.ErrorCode == 405)
+            {
+                return this.Configuration.ApiClient.Execute<Object>(localVarPath,
+                    Method.Get, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
+                    localVarFileParams, localVarPathParams, localVarHttpContentType, this.Configuration,
+                    ExceptionFactory, operationName);
+            }
+        }
+
+        private async ThreadTask.Task<ApiResponse<Object>> ExecuteStateChangeAsync(
+            string localVarPath, List<KeyValuePair<String, String>> localVarQueryParams, Object localVarPostBody,
+            Dictionary<String, String> localVarHeaderParams, Dictionary<String, String> localVarFormParams,
+            Dictionary<String, FileParameter> localVarFileParams, Dictionary<String, String> localVarPathParams,
+            String localVarHttpContentType, string operationName)
+        {
+            try
+            {
+                return await this.Configuration.ApiClient.ExecuteAsync<Object>(localVarPath,
+                    Method.Put, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
+                    localVarFileParams, localVarPathParams, localVarHttpContentType, this.Configuration,
+                    ExceptionFactory, operationName);
+            }
+            catch (ApiException e) when (e.ErrorCode == 405)
+            {
+                return await this.Configuration.ApiClient.ExecuteAsync<Object>(localVarPath,
+                    Method.Get, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
+                    localVarFileParams, localVarPathParams, localVarHttpContentType, this.Configuration,
+                    ExceptionFactory, operationName);
+            }
+        }
+
         /// <summary>
-        /// Pauses an existing schedule by name 
+        /// Pauses an existing schedule by name
         /// </summary>
         /// <exception cref="Conductor.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="name"></param>
@@ -822,10 +866,9 @@ namespace Conductor.Api
 
             if (name != null) localVarPathParams.Add("name", this.Configuration.ApiClient.ParameterToString(name)); // path parameter
 
-            return (await this.Configuration.ApiClient.ExecuteAsync<Object>(localVarPath,
-                Method.Get, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
-                localVarFileParams, localVarPathParams, localVarHttpContentType, this.Configuration,
-                ExceptionFactory, "PauseSchedule")).Data;
+            return (await ExecuteStateChangeAsync(localVarPath,
+                localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
+                localVarFileParams, localVarPathParams, localVarHttpContentType, "PauseSchedule")).Data;
         }
 
         /// <summary>
@@ -863,10 +906,9 @@ namespace Conductor.Api
 
             if (name != null) localVarPathParams.Add("name", this.Configuration.ApiClient.ParameterToString(name)); // path parameter
 
-            return this.Configuration.ApiClient.Execute<Object>(localVarPath,
-                Method.Get, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
-                localVarFileParams, localVarPathParams, localVarHttpContentType, this.Configuration,
-                ExceptionFactory, "PauseSchedule");
+            return ExecuteStateChange(localVarPath,
+                localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
+                localVarFileParams, localVarPathParams, localVarHttpContentType, "PauseSchedule");
         }
 
         /// <summary>
@@ -1194,10 +1236,9 @@ namespace Conductor.Api
 
             if (name != null) localVarPathParams.Add("name", this.Configuration.ApiClient.ParameterToString(name)); // path parameter
 
-            return (await this.Configuration.ApiClient.ExecuteAsync<Object>(localVarPath,
-                Method.Get, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
-                localVarFileParams, localVarPathParams, localVarHttpContentType, this.Configuration,
-                ExceptionFactory, "ResumeSchedule")).Data;
+            return (await ExecuteStateChangeAsync(localVarPath,
+                localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
+                localVarFileParams, localVarPathParams, localVarHttpContentType, "ResumeSchedule")).Data;
         }
 
         /// <summary>
@@ -1235,10 +1276,9 @@ namespace Conductor.Api
 
             if (name != null) localVarPathParams.Add("name", this.Configuration.ApiClient.ParameterToString(name)); // path parameter
 
-            return this.Configuration.ApiClient.Execute<Object>(localVarPath,
-                Method.Get, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
-                localVarFileParams, localVarPathParams, localVarHttpContentType, this.Configuration,
-                ExceptionFactory, "ResumeSchedule");
+            return ExecuteStateChange(localVarPath,
+                localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
+                localVarFileParams, localVarPathParams, localVarHttpContentType, "ResumeSchedule");
         }
 
         /// <summary>

--- a/Tests/ApiUnit/SchedulerResourceApiUnitTest.cs
+++ b/Tests/ApiUnit/SchedulerResourceApiUnitTest.cs
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Conductor.Api;
+using Conductor.Client;
+using conductor_csharp.test.Helper;
+using Xunit;
+
+namespace conductor_csharp.test.ApiUnit
+{
+    [Trait("Category", "Unit")]
+    public class SchedulerResourceApiUnitTest
+    {
+        [Fact]
+        public void PauseSchedule_SendsPutFirst()
+        {
+            var (client, handler) = MockApiClient.Build<SchedulerResourceApi>(HttpStatusCode.OK, "{}");
+
+            client.PauseSchedule("s1");
+
+            var request = Assert.Single(handler.Requests);
+            Assert.Equal(HttpMethod.Put, request.Method);
+            Assert.Equal("/api/scheduler/schedules/s1/pause", request.RequestUri.AbsolutePath);
+        }
+
+        [Fact]
+        public void PauseSchedule_FallsBackToGetOn405()
+        {
+            var (client, handler) = MockApiClient.Build<SchedulerResourceApi>(req =>
+                req.Method == HttpMethod.Put ? (HttpStatusCode.MethodNotAllowed, "") : (HttpStatusCode.OK, "{}"));
+
+            client.PauseSchedule("s1");
+
+            Assert.Equal(2, handler.Requests.Count);
+            Assert.Equal(HttpMethod.Put, handler.Requests[0].Method);
+            Assert.Equal(HttpMethod.Get, handler.Requests[1].Method);
+            Assert.Equal("/api/scheduler/schedules/s1/pause", handler.Requests[1].RequestUri.AbsolutePath);
+        }
+
+        [Fact]
+        public void ResumeSchedule_FallsBackToGetOn405Independently_EachCallRetriesPutFirst()
+        {
+            var (client, handler) = MockApiClient.Build<SchedulerResourceApi>(req =>
+                req.Method == HttpMethod.Put ? (HttpStatusCode.MethodNotAllowed, "") : (HttpStatusCode.OK, "{}"));
+
+            client.PauseSchedule("s1");
+            client.ResumeSchedule("s1");
+
+            Assert.Equal(4, handler.Requests.Count);
+            Assert.Equal(HttpMethod.Put, handler.Requests[2].Method);
+            Assert.Equal(HttpMethod.Get, handler.Requests[3].Method);
+            Assert.Equal("/api/scheduler/schedules/s1/resume", handler.Requests[3].RequestUri.AbsolutePath);
+        }
+
+        [Fact]
+        public void PauseSchedule_RethrowsOn403WithoutFallingBackToGet()
+        {
+            var (client, handler) = MockApiClient.Build<SchedulerResourceApi>(HttpStatusCode.Forbidden, "");
+
+            var ex = Assert.Throws<ApiException>(() => client.PauseSchedule("s1"));
+
+            Assert.Equal(403, ex.ErrorCode);
+            Assert.Single(handler.Requests);
+        }
+
+        [Fact]
+        public void PauseSchedule_RethrowsOn404WithoutFallingBackToGet()
+        {
+            var (client, handler) = MockApiClient.Build<SchedulerResourceApi>(HttpStatusCode.NotFound, "");
+
+            var ex = Assert.Throws<ApiException>(() => client.PauseSchedule("s1"));
+
+            Assert.Equal(404, ex.ErrorCode);
+            Assert.Single(handler.Requests);
+        }
+
+        [Fact]
+        public async Task ResumeScheduleAsync_FallsBackToGetOn405()
+        {
+            var callCount = 0;
+            var (client, handler) = MockApiClient.Build<SchedulerResourceApi>(_ =>
+            {
+                callCount++;
+                return callCount == 1 ? (HttpStatusCode.MethodNotAllowed, "") : (HttpStatusCode.OK, "{}");
+            });
+
+            await client.ResumeScheduleAsync("s1");
+
+            Assert.Equal(2, handler.Requests.Count);
+            Assert.Equal(HttpMethod.Put, handler.Requests[0].Method);
+            Assert.Equal(HttpMethod.Get, handler.Requests[1].Method);
+            Assert.Equal("/api/scheduler/schedules/s1/resume", handler.Requests[1].RequestUri.AbsolutePath);
+        }
+
+        [Fact]
+        public async Task ResumeScheduleAsync_RethrowsOn403WithoutFallingBackToGet()
+        {
+            var (client, handler) = MockApiClient.Build<SchedulerResourceApi>(HttpStatusCode.Forbidden, "");
+
+            var ex = await Assert.ThrowsAsync<ApiException>(() => client.ResumeScheduleAsync("s1"));
+
+            Assert.Equal(403, ex.ErrorCode);
+            Assert.Single(handler.Requests);
+        }
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- Schedule pause/resume verb differs by server family (OSS/embedded Conductor accepts PUT only,
  Orkes Conductor historically accepted GET only) — both `SchedulerResourceApi` (the generated
  client) and `Schedules` (the AI scheduling facade) sent a single hardcoded verb, so each only
  worked against one server family
- Both now try PUT first on every call, falling back to GET only on a 405 — no cached state, no
  shared verdict between pause and resume
- Any other error status (403, 404, 5xx) propagates immediately, no fallback attempted
- No public API changes — same method signatures, same return types, same exceptions on real
  failures

Alternatives considered
----
- Switch the hardcoded verb from GET to PUT outright — rejected, breaks any Orkes deployment
  that hasn't picked up server-side PUT support yet
- Cache the fallback verdict per client instance (matching the Java SDK client) — rejected in
  favor of a simpler, stateless per-call retry
