### PR TITLE
make attribute-based worker discovery configurable

### DIFF
--- a/Conductor/Client/Extensions/DependencyInjectionExtensions.cs
+++ b/Conductor/Client/Extensions/DependencyInjectionExtensions.cs
@@ -16,7 +16,9 @@ using Conductor.Client.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
+using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 
 namespace Conductor.Client.Extensions
 {
@@ -62,6 +64,33 @@ namespace Conductor.Client.Extensions
         {
             services.AddHostedService<WorkflowTaskService>();
             return services;
+        }
+
+        public static IServiceCollection ConfigureConductorWorkerDiscovery(this IServiceCollection services, Action<WorkerDiscoveryOptions> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            services.AddOptions<WorkerDiscoveryOptions>().Configure(configure);
+
+            return services;
+        }
+
+        public static IServiceCollection ConfigureConductorWorkerDiscovery(this IServiceCollection services, WorkerDiscoveryOptions discoveryOptions)
+        {
+            if (discoveryOptions == null)
+            {
+                throw new ArgumentNullException(nameof(discoveryOptions));
+            }
+
+            var assemblies = discoveryOptions.Assemblies?.ToArray() ?? Array.Empty<Assembly>();
+
+            return services.ConfigureConductorWorkerDiscovery(options =>
+            {
+                options.Assemblies = assemblies;
+            });
         }
     }
 }

--- a/Conductor/Client/Worker/WorkerDiscoveryOptions.cs
+++ b/Conductor/Client/Worker/WorkerDiscoveryOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Conductor.Client.Worker
+{
+
+    public sealed class WorkerDiscoveryOptions
+    {
+        public bool EnableAttributeDiscovery { get; set; } = true;
+
+        /// <summary>
+        /// Empty means: preserve current behaviour and scan all loaded assemblies.
+        /// </summary>
+        public IReadOnlyCollection<Assembly> Assemblies { get; set; } = Array.Empty<Assembly>();
+    }
+}

--- a/Conductor/Client/Worker/WorkflowTaskCoordinator.cs
+++ b/Conductor/Client/Worker/WorkflowTaskCoordinator.cs
@@ -13,8 +13,10 @@
 using Conductor.Client.Interfaces;
 using Conductor.Client.Telemetry;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,8 +31,14 @@ namespace Conductor.Client.Worker
         private readonly HashSet<IWorkflowTaskExecutor> _workers;
         private readonly IWorkflowTaskClient _client;
         private readonly MetricsCollector _metrics;
+        private readonly WorkerDiscoveryOptions _workerDiscoveryOptions;
 
-        public WorkflowTaskCoordinator(IWorkflowTaskClient client, ILogger<WorkflowTaskCoordinator> logger, ILogger<WorkflowTaskExecutor> loggerWorkflowTaskExecutor, ILogger<WorkflowTaskMonitor> loggerWorkflowTaskMonitor, MetricsCollector metrics = null)
+        public WorkflowTaskCoordinator(IWorkflowTaskClient client,
+                                       ILogger<WorkflowTaskCoordinator> logger,
+                                       ILogger<WorkflowTaskExecutor> loggerWorkflowTaskExecutor,
+                                       ILogger<WorkflowTaskMonitor> loggerWorkflowTaskMonitor,
+                                       MetricsCollector metrics = null,
+                                       IOptions<WorkerDiscoveryOptions> workerDiscoveryOptions = null)
         {
             _logger = logger;
             _client = client;
@@ -38,6 +46,8 @@ namespace Conductor.Client.Worker
             _loggerWorkflowTaskExecutor = loggerWorkflowTaskExecutor;
             _loggerWorkflowTaskMonitor = loggerWorkflowTaskMonitor;
             _metrics = metrics;
+
+            _workerDiscoveryOptions = workerDiscoveryOptions?.Value ?? new WorkerDiscoveryOptions();
         }
 
         public async Task Start(CancellationToken token)
@@ -46,7 +56,12 @@ namespace Conductor.Client.Worker
                 token.ThrowIfCancellationRequested();
 
             _logger.LogDebug("Starting workers...");
-            DiscoverWorkers();
+
+            if (_workerDiscoveryOptions.EnableAttributeDiscovery)
+            {
+                DiscoverWorkers();
+            }
+
             var runningWorkers = new List<Task>();
             foreach (var worker in _workers)
             {
@@ -72,7 +87,9 @@ namespace Conductor.Client.Worker
 
         private void DiscoverWorkers()
         {
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            var assemblies = _workerDiscoveryOptions.Assemblies?.Any() == true ? _workerDiscoveryOptions.Assemblies : AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
             {
                 foreach (var type in assembly.GetTypes())
                 {
@@ -80,6 +97,7 @@ namespace Conductor.Client.Worker
                     {
                         continue;
                     }
+
                     foreach (var method in type.GetMethods())
                     {
                         var workerTask = method.GetCustomAttribute<WorkerTask>();

--- a/Tests/Extensions/DependencyInjectionExtensionsTests.cs
+++ b/Tests/Extensions/DependencyInjectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2024 Conductor Authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -12,7 +12,11 @@
  */
 using Conductor.Client.Extensions;
 using Conductor.Client.Telemetry;
+using Conductor.Client.Worker;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace Tests.Extensions
@@ -87,6 +91,67 @@ namespace Tests.Extensions
 
             var provider = services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<Conductor.Client.Configuration>());
+        }
+
+        [Fact]
+        public void ConfigureConductorWorkerDiscovery_WithoutConfiguration_UsesEmptyAssemblyCollection()
+        {
+            var services = new ServiceCollection();
+
+            services.AddConductorWorker();
+
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<WorkerDiscoveryOptions>>().Value;
+
+            Assert.Empty(options.Assemblies);
+        }
+
+        [Fact]
+        public void ConfigureConductorWorkerDiscovery_WithAction_ConfiguresAssemblyCollection()
+        {
+            var services = new ServiceCollection();
+            var assembly = typeof(DependencyInjectionExtensionsTests).Assembly;
+
+            services.ConfigureConductorWorkerDiscovery(options =>
+                options.Assemblies = new[] { assembly });
+
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<WorkerDiscoveryOptions>>().Value;
+
+            Assert.Contains(assembly, options.Assemblies);
+        }
+
+        [Fact]
+        public void ConfigureConductorWorkerDiscovery_WithAttributeDiscoveryDisabled_ConfiguresOptions()
+        {
+            var services = new ServiceCollection();
+
+            services.ConfigureConductorWorkerDiscovery(options =>
+                options.EnableAttributeDiscovery = false);
+
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<WorkerDiscoveryOptions>>().Value;
+
+            Assert.False(options.EnableAttributeDiscovery);
+        }
+
+        [Fact]
+        public void ConfigureConductorWorkerDiscovery_WithOptions_CopiesAssemblyCollection()
+        {
+            var services = new ServiceCollection();
+            var assembly = typeof(DependencyInjectionExtensionsTests).Assembly;
+            var assemblies = new List<Assembly> { assembly };
+
+            services.ConfigureConductorWorkerDiscovery(new WorkerDiscoveryOptions
+            {
+                Assemblies = assemblies
+            });
+            assemblies.Clear();
+
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<WorkerDiscoveryOptions>>().Value;
+
+            Assert.Contains(assembly, options.Assemblies);
         }
     }
 }

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -94,6 +94,33 @@ settings. See [deployment-scaling.md](deployment-scaling.md) for sizing guidance
 `IServiceCollection`, so workers can take constructor dependencies and participate in
 the host's lifetime. This is the preferred shape for anything beyond a sample.
 
+### Choose one registration path per worker
+
+The SDK supports two worker registration paths:
+
+- Register an `IWorkflowTask` explicitly in the service collection, for example with
+  `AddConductorWorkflowTask` or `ServiceDescriptor.Singleton<IWorkflowTask, TWorker>()`.
+- Discover methods annotated with `[WorkerTask]` when the worker host starts.
+
+Choose one path for each worker. Do not explicitly register a worker that is also
+discovered through `[WorkerTask]`, or the host creates two polling workers for it.
+
+By default, attribute discovery scans all assemblies loaded in the process. To limit
+the scan to the assembly containing your annotated workers, configure discovery while
+building the service collection:
+
+```csharp
+services.AddConductorWorker(configuration);
+services.ConfigureConductorWorkerDiscovery(options =>
+{
+    options.Assemblies = new[] { typeof(MyAnnotatedWorker).Assembly };
+});
+services.WithHostedService();
+```
+
+This setting affects only `[WorkerTask]` discovery. It does not affect any
+`IWorkflowTask` registered in the service collection.
+
 ## Metrics
 
 The worker framework records polling, execution, update, and error metrics via


### PR DESCRIPTION
## Summary

Makes attribute-based worker discovery configurable.

Applications can now:

- keep the existing automatic scan of loaded assemblies;
- restrict `[WorkerTask]` discovery to selected assemblies; or
- disable attribute discovery and use only `IWorkflowTask` workers registered through DI.

Explicit DI registrations remain unchanged. This is useful for worker hosts that register their workers through `IWorkflowTask` and do not need reflection-based discovery.

## Changes

- Added `WorkerDiscoveryOptions`.
- Added `ConfigureConductorWorkerDiscovery(...)` overloads for an options object or configuration callback.
- Updated `WorkflowTaskCoordinator` to honor `EnableAttributeDiscovery` and configured assemblies.
- Added worker-discovery configuration tests.
- Documented the two worker registration paths and advised using one path per worker.

## Backwards compatibility

Attribute discovery remains enabled by default and continues to scan all loaded assemblies unless configured otherwise.

## Why

The worker host previously reflected over every assembly loaded in the process to find `[WorkerTask]` methods. In applications with optional third-party dependencies, that can inspect assemblies unrelated to the worker platform and trigger type-loading failures when an optional dependency is unavailable.

This change lets applications restrict or disable attribute-based discovery when they register workers explicitly through DI.